### PR TITLE
feat: bootstrap mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 **/.vscode/
+**/.idea/
 
 car_files*
 
@@ -15,6 +16,7 @@ config.toml
 Cargo.lock
 
 index_provider_db*
+keystore*
 test_db*
 ursa_db*
 data*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ relay = false
 autonat = false
 bootstrap_nodes = ["/ip4/127.0.0.1/tcp/6009"]
 swarm_addr = "/ip4/0.0.0.0/tcp/6009"
-database_path = "data/ursadb"
+database_path = "data/ursa_db"
 ```
 
 ### Run with Docker

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -22,6 +22,8 @@ pub struct UrsaConfig {
     pub autonat: bool,
     /// Swarm listening Address.
     pub swarm_addr: Multiaddr,
+    /// Run with bootstrap node configuration.
+    pub bootstrap_mode: bool,
     /// Bootstrap nodes.
     pub bootstrap_nodes: Vec<Multiaddr>,
     /// Database path.
@@ -43,6 +45,7 @@ impl Default for UrsaConfig {
             mdns: false,
             relay: false,
             autonat: false,
+            bootstrap_mode: false,
             bootstrap_nodes,
             swarm_addr: "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
             database_path: Some(PathBuf::from(DEFAULT_DB_PATH_STR)),
@@ -60,6 +63,7 @@ impl UrsaConfig {
             autonat: self.autonat | other.autonat,
             identity: self.identity,
             swarm_addr: self.swarm_addr,
+            bootstrap_mode: self.bootstrap_mode | other.bootstrap_mode,
             bootstrap_nodes: self.bootstrap_nodes,
             database_path: self.database_path.or(other.database_path),
             keystore_path: self.keystore_path,

--- a/crates/ursa-network/src/gossipsub.rs
+++ b/crates/ursa-network/src/gossipsub.rs
@@ -14,6 +14,17 @@ use libp2p::{
     identity::Keypair,
 };
 
+const BOOTSTRAP_MESH_N: usize = 0;
+const BOOTSTRAP_MESH_LOW: usize = 0;
+const BOOTSTRAP_MESH_HIGH: usize = 0;
+// D out
+const BOOTSTRAP_MESH_OUTBOUND_MIN: usize = 0;
+
+const NODE_MESH_N: usize = 8;
+const NODE_MESH_LOW: usize = 4;
+const NODE_MESH_HIGH: usize = 12;
+const NODE_MESH_OUTBOUND_MIN: usize = (NODE_MESH_N / 2) - 1;
+
 const URSA_GOSSIP_PROTOCOL: &str = "ursa/gossipsub/0.0.1";
 
 ///
@@ -22,14 +33,25 @@ pub struct UrsaGossipsub;
 
 impl UrsaGossipsub {
     pub fn new(keypair: &Keypair, config: &UrsaConfig) -> Gossipsub {
-        let mesh_n = 8;
-        let mesh_n_low = 4;
-        let mesh_n_high = 12;
+        let (mesh_n, mesh_n_low, mesh_n_high, mesh_outbound_min) = if config.bootstrap_mode {
+            (
+                BOOTSTRAP_MESH_N,
+                BOOTSTRAP_MESH_LOW,
+                BOOTSTRAP_MESH_HIGH,
+                BOOTSTRAP_MESH_OUTBOUND_MIN,
+            )
+        } else {
+            (
+                NODE_MESH_N,
+                NODE_MESH_LOW,
+                NODE_MESH_HIGH,
+                NODE_MESH_OUTBOUND_MIN,
+            )
+        };
+
         let gossip_lazy = mesh_n;
         let heartbeat_interval = Duration::from_secs(1);
         let fanout_ttl = Duration::from_secs(60);
-        // D_out
-        let mesh_outbound_min = (mesh_n / 2) - 1;
         let max_transmit_size = 4 * 1024 * 1024;
         // todo(botch): should we limit the number here?
         let max_msgs_per_rpc = 1;

--- a/crates/ursa/src/ursa/mod.rs
+++ b/crates/ursa/src/ursa/mod.rs
@@ -65,11 +65,17 @@ pub struct CliOpts {
         help = "Identity name. If not provided, a default identity will be created and reused automatically"
     )]
     pub identity: Option<String>,
+    #[structopt(
+        long,
+        help = "Run the node in bootstrap mode, using a slightly different mesh configuration. Defaults to false"
+    )]
+    pub boostrap_mode: Option<bool>,
 }
 
 impl CliOpts {
     pub fn to_config(&self) -> Result<UrsaConfig> {
         let mut cfg = UrsaConfig::default();
+
         if let Some(config_file) = &self.config {
             info!(
                 "Reading configuration from user provided config file {}",
@@ -83,6 +89,9 @@ impl CliOpts {
         }
         if let Some(identity) = &self.identity {
             cfg.identity = identity.to_string();
+        }
+        if let Some(bootstrap_mode) = self.boostrap_mode {
+            cfg.bootstrap_mode = bootstrap_mode;
         }
 
         Ok(cfg)


### PR DESCRIPTION
Adds a bootstrap mode using the spec's mesh configuration. This allows for running the bootstrap nodes from the same binary and git branch for ease of deployment and maintenance.

Open topics:
Users should not be encouraged to run bootstrap nodes, slim down where the option is present and hide the functionality