### PR TITLE
docs: dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Ursa
 
-> Ursa, a decentralized content delivery network.
+Ursa, a decentralized content delivery network.
 
 ## Run a node
 
-### Dependencies
+### Build Dependencies
 
-- rust (^1.65.0)
+> If docker is used, no dependencies are not required other than `make`
+- (optional) docker
 - make
+- rust (`^1.65.0`)
 - build-essential
 - libclang
 - cmake
-- (optional) docker
 
 ### Run with cli
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 ## Run a node
 
+### Dependencies
+
+- rust (^1.65.0)
+- make
+- build-essential
+- libclang
+- cmake
+- (optional) docker
+
 ### Run with cli
 
 Build and install the latest *HEAD* version:


### PR DESCRIPTION
Adds the local dependencies needed to compile and run the project.
When using docker, only `make` is needed