### PR TITLE
Register poll method

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -130,7 +130,11 @@ pub enum BehaviourEvent {
 ///
 /// The events generated [`BehaviourEvent`].
 #[derive(NetworkBehaviour)]
-#[behaviour(out_event = "BehaviourEvent", event_process = true)]
+#[behaviour(
+    out_event = "BehaviourEvent",
+    poll_method = "poll",
+    event_process = true
+)]
 pub struct Behaviour<P: StoreParams> {
     /// Alive checks.
     ping: Ping,


### PR DESCRIPTION
`Behaviour`'s poll method was unregistered in #65. This registers it again.