### PR TITLE
fix: 🐛 bind docker container ports to host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-run-dev:
 	docker run --name ursa-dev -it ursa-dev
 
 docker-run:
-	docker run --name ursa-cli -it ursa
+	docker run -p 4069:4069 --name ursa-cli -it ursa
 
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-run-dev:
 	docker run --name ursa-dev -it ursa-dev
 
 docker-run:
-	docker run -p 4069:4069 --name ursa-cli -it ursa
+	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 --name ursa-cli -it ursa
 
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-run-dev:
 	docker run --name ursa-dev -it ursa-dev
 
 docker-run:
-	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 --name ursa-cli -it ursa
+	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 -p 8070:8070 --name ursa-cli -it ursa
 
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up


### PR DESCRIPTION
## Why?

The docker-run would ultimately run the docker container without exposing the necessary ports to the host, thus this PR declares it.