### PR TITLE
fix: properly handle cid not found in blockstore

### DIFF
--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -74,8 +74,8 @@ where
 
             if code != 200 {
                 error!(
-                    "[RPCClient] - server responded with the error code {:?}",
-                    code
+                    "[RPCClient] - server responded with http error code {:?} - {}",
+                    code, res
                 );
                 return Err(Error::Full {
                     message: format!("Error code from HTTP Response: {}", code),
@@ -91,10 +91,7 @@ where
                     return Err(Error::Full {
                         data: None,
                         code: 200,
-                        message: format!(
-                            "Parse Error: Response from RPC endpoint could not be parsed. Error was: {}",
-                            e,
-                        ),
+                        message: format!("Parse Error: {}\nData: {}", e, res),
                     })
                 }
             };

--- a/crates/ursa-rpc-server/src/api.rs
+++ b/crates/ursa-rpc-server/src/api.rs
@@ -110,7 +110,7 @@ where
     }
 
     async fn get_data(&self, root_cid: Cid) -> Result<Vec<(lCid, Vec<u8>)>> {
-        if !self.store.blockstore().has(&root_cid).unwrap() {
+        if !self.store.blockstore().has(&root_cid)? {
             let (sender, receiver) = oneshot::channel();
             let request = UrsaCommand::GetBitswap {
                 cid: root_cid,
@@ -154,10 +154,10 @@ where
                 .await
                 .unwrap()
         });
-        let dag = self.get_data(root_cid).await.unwrap();
+        let dag = self.get_data(root_cid).await?;
 
         for (cid, data) in dag {
-            tx.send((convert_cid(cid.to_bytes()), data)).await.unwrap();
+            tx.send((convert_cid(cid.to_bytes()), data)).await?;
         }
         drop(tx);
         write_task.await?;
@@ -165,7 +165,7 @@ where
         let buffer: Vec<_> = buffer.read().await.clone();
         let file_path = PathBuf::from(path).join(format!("{}.car", root_cid));
         create_dir_all(file_path.parent().unwrap()).await?;
-        let mut file = File::create(file_path).await.unwrap();
+        let mut file = File::create(file_path).await?;
         file.write_all(&buffer).await?;
         Ok(())
     }
@@ -190,10 +190,10 @@ where
                 .await
                 .unwrap()
         });
-        let dag = self.get_data(root_cid).await.unwrap();
+        let dag = self.get_data(root_cid).await?;
 
         for (cid, data) in dag {
-            tx.send((convert_cid(cid.to_bytes()), data)).await.unwrap();
+            tx.send((convert_cid(cid.to_bytes()), data)).await?;
         }
         drop(tx);
 


### PR DESCRIPTION
We are unwrapping a lot in the rpc code, which causes panics and no response to the client. We should properly return errors to the client.

Node:
![image](https://user-images.githubusercontent.com/8976745/207230939-5f332f89-2325-47c6-9963-f279ee886d58.png)

Client:
![image](https://user-images.githubusercontent.com/8976745/207230970-7adc6a6a-fdb5-4bf6-84ad-8c749a5f0c97.png)
