### PR TITLE
chore: workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,65 @@ exclude = [
 lto = true
 opt-level = 'z'
 codegen-units = 1
+
+[workspace.dependencies]
+anyhow = "1.0.67"
+async-fs = "1.6.0"
+async-trait = "0.1.60"
+axum = { version = "0.6.1", features = ["multipart", "headers"] }
+axum-server = { version = "0.4.4", features = ["tls-rustls"] }
+base64 = "0.20.0"
+bincode = "1.3.3"
+bytes = "1.3.0"
+cid = "0.8.6"
+clap = { version = "4.0.29", features = ["derive"] }
+ctrlc = "3.2.4"
+db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
+dirs = "4"
+dotenv = "0.15.0"
+fnv = "1.0.7"
+forest_encoding = "0.2.2"
+forest_ipld = "0.1.1"
+futures = "0.3.25"
+futures-util = "0.3.25"
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_car = "0.6.0"
+fvm_ipld_encoding = "0.3.0"
+hyper = { version = "0.14.23", features = ["full"] }
+hyper-tls = "0.5.0"
+jsonrpc-v2 = "0.11.0"
+libipld = { version = "0.14.0", default-features = false }
+libp2p = { version = "0.50.0", default-features = false }
+libp2p-bitswap = "0.25.0"
+libipld-cbor = "0.14.0"
+libp2p-swarm = "0.41.1"
+metrics = "0.20.1"
+metrics-exporter-prometheus = "0.11.0"
+pem = "1.1.0"
+prometheus-client = "0.18.0"
+rand = "0.8.5"
+resolve-path = "0.1.0"
+serde = "1.0.151"
+serde_json = "1.0.91"
+serde_with = { version = "2.1.0", features = ["base64"] }
+simple_logger = "4.0.0"
+structopt = "0.3"
+surf = { version = "2.3.2", default-features = true, features = ["curl-client"] }
+thiserror = "1.0.30"
+tokio = { version = "1.23.0", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io", "compat"] }
+toml = "0.5.10"
+tower = "0.4.13"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+
+
+
+
+
+
+
+
+
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,3 @@ toml = "0.5.10"
 tower = "0.4.13"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-
-
-
-
-
-
-
-
-
-
-

--- a/crates/ursa-gateway/Cargo.toml
+++ b/crates/ursa-gateway/Cargo.toml
@@ -8,19 +8,18 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's proxy gateway"
 
 [dependencies]
-anyhow = "1.0.66"
-axum = "0.6.1"
-axum-server = { version = "0.4.4", features = ["tls-rustls"] }
-cid = "0.9.0"
-clap = { version = "4.0.29", features = ["derive"] }
-forest_ipld = "0.1.1"
-hyper = { version = "0.14.23", features = ["full"] }
-hyper-tls = "0.5.0"
-multiaddr = "0.17.0"
-multihash = "0.18.0"
-serde = { version = "1.0.149", features = ["derive"] }
-serde_json = "1.0.89"
-tokio = { version = "1.23.0", features = ["full"] }
-toml = "0.5.9"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+anyhow.workspace = true
+axum.workspace = true
+axum-server.workspace = true
+cid.workspace = true
+clap.workspace = true
+forest_ipld.workspace = true
+hyper.workspace = true
+hyper-tls.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+libp2p.workspace = true

--- a/crates/ursa-gateway/src/indexer/model.rs
+++ b/crates/ursa-gateway/src/indexer/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use libp2p::Multiaddr;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct IndexerResponse {
@@ -29,5 +30,5 @@ pub struct AddrInfo {
     #[serde(rename = "ID")]
     id: String,
     #[serde(rename = "Addrs")]
-    addrs: Vec<multiaddr::Multiaddr>,
+    addrs: Vec<Multiaddr>,
 }

--- a/crates/ursa-gateway/src/indexer/model.rs
+++ b/crates/ursa-gateway/src/indexer/model.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct IndexerResponse {

--- a/crates/ursa-index-provider/Cargo.toml
+++ b/crates/ursa-index-provider/Cargo.toml
@@ -5,41 +5,35 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.63"
-async-fs = "1.6.0"
-async-trait = "0.1.53"
-axum = "0.5.15"
-base64 = "0.13.0"
-bincode = "1.3.3"
-bytes = "1.1.0"
-cbor = "0.4.1"
-cid = "0.8.6"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-dirs = "4"
-forest_encoding = "0.2"
-forest_ipld = "0.1"
-futures = "0.3.21"
-fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_car = "0.5.0"
-libipld = "0.14.0"
-libipld-cbor = "0.14.0"
-# libp2p = { version = "0.50.0", default-features = false, features = ["identify", "serde"] }
-libp2p = "0.50.0"
-multihash = { version = "0.16.3", features = ["identity"] }
-rand = "0.8.4"
-rustc-serialize = "0.3.24"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.74"
-serde_with = { version = "1.11.0", features = ["base64"] }
-simple_logger = "4.0.0"
-surf = { version = "2.3", default-features = true, features = ["curl-client"] }
-thiserror = "1.0.30"
-tokio = { version = "1.20.1", features = ["full"] }
-tracing = "0.1.36" 
+anyhow.workspace = true
+async-fs.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+tracing-subscriber.workspace = true
+base64.workspace = true
+bincode.workspace = true
+bytes.workspace = true
+cid.workspace = true
+db.workspace = true
+dirs.workspace = true
+forest_encoding.workspace = true
+forest_ipld.workspace = true
+futures.workspace = true
+fvm_ipld_blockstore.workspace = true
+fvm_ipld_car.workspace = true
+libipld.workspace = true
+libipld-cbor.workspace = true
+libp2p.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+simple_logger.workspace = true
+surf.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 ursa-network = { path = "../ursa-network" }
 ursa-store = { path = "../ursa-store" }
 ursa-utils ={ path = "../ursa-utils" }
-
-[dev-dependencies]
-ursa-network = { path = "../ursa-network" }
 

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -1,10 +1,10 @@
+use cid::multihash::{ MultihashDigest, Code};
 use forest_ipld::Ipld;
 use libp2p::{
     core::{signed_envelope, SignedEnvelope},
     identity::Keypair,
     PeerId,
 };
-use multihash::MultihashDigest;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -116,7 +116,7 @@ impl Advertisement {
         payload.extend_from_slice(metadata);
         payload.extend_from_slice(&is_rm_payload);
 
-        Ok(multihash::Code::Sha2_256.digest(&payload).to_bytes())
+        Ok(Code::Sha2_256.digest(&payload).to_bytes())
     }
 }
 

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -1,4 +1,4 @@
-use cid::multihash::{ MultihashDigest, Code};
+use cid::multihash::{Code, MultihashDigest};
 use forest_ipld::Ipld;
 use libp2p::{
     core::{signed_envelope, SignedEnvelope},

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -8,14 +8,13 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use cid::Cid;
+use cid::{Cid, multihash::Code};
 use forest_encoding::Cbor;
 use forest_ipld::Ipld;
 use fvm_ipld_blockstore::Blockstore;
 use libipld::codec::Encode;
 use libipld_cbor::DagCborCodec;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
-use multihash::Code;
 use rand;
 use rand::Rng;
 use serde::{Deserialize, Serialize};

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -8,7 +8,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use cid::{Cid, multihash::Code};
+use cid::{multihash::Code, Cid};
 use forest_encoding::Cbor;
 use forest_ipld::Ipld;
 use fvm_ipld_blockstore::Blockstore;

--- a/crates/ursa-index-provider/src/tests/provider_tests.rs
+++ b/crates/ursa-index-provider/src/tests/provider_tests.rs
@@ -6,8 +6,8 @@ mod tests {
     };
 
     use anyhow::Error;
-    use forest_ipld::Ipld;
     use cid::multihash::{Code, MultihashDigest};
+    use forest_ipld::Ipld;
     use surf::Error as SurfError;
     use tokio::task;
     use tracing::error;

--- a/crates/ursa-index-provider/src/tests/provider_tests.rs
+++ b/crates/ursa-index-provider/src/tests/provider_tests.rs
@@ -7,7 +7,7 @@ mod tests {
 
     use anyhow::Error;
     use forest_ipld::Ipld;
-    use multihash::{Code, MultihashDigest};
+    use cid::multihash::{Code, MultihashDigest};
     use surf::Error as SurfError;
     use tokio::task;
     use tracing::error;

--- a/crates/ursa-metrics/Cargo.toml
+++ b/crates/ursa-metrics/Cargo.toml
@@ -9,11 +9,12 @@ description = "Ursa metrics"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.56"
-axum = "0.5.7"
-libp2p-swarm = "0.37.0"
-metrics = "0.20.1"
-metrics-exporter-prometheus = "0.11.0"
-prometheus-client = "0.18.0"
-serde = { version = "1.0", features = ["derive"] }
-tracing = "0.1.33"
+anyhow.workspace = true
+axum.workspace = true
+tracing-subscriber.workspace = true
+libp2p-swarm .workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+prometheus-client.workspace =true
+serde.workspace = true
+tracing.workspace = true

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -62,6 +62,4 @@ features = [
 ]
 
 [dev-dependencies]
-db.workspace = true
 simple_logger.workspace = true
-tokio.workspace = true

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -8,40 +8,36 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's libp2p implementation"
 
 [dependencies]
-anyhow = "1.0.56"
-async-fs = "1.6.0"
-async-trait = "0.1.53"
-bytes = "1.1.0"
-cid = "0.8.6"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-dirs = "4"
-fnv = "1.0.7"
-forest_encoding = "0.2.2"
-forest_ipld = "0.1.1"
-futures = "0.3.21"
-futures-util = "0.3.21"
-fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_car = "0.5.0"
-jsonrpc-v2 = "0.11.0"
-libp2p-bitswap = "0.25.0"
-log = "0.4.17"
-metrics = "0.20.1"
-rand = "0.8.4"
-serde = "1.0.137"
-serde_json = "1.0.81"
-surf = "2.3.2"
-tokio = { version = "1.20.1", features = ["full"] }
-tracing = "0.1.33"
+anyhow.workspace = true
+async-fs.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+cid.workspace = true
+db.workspace = true
+dirs.workspace = true
+fnv.workspace = true
+forest_encoding.workspace = true
+forest_ipld.workspace = true
+futures.workspace = true
+futures-util.workspace = true
+fvm_ipld_blockstore.workspace = true
+fvm_ipld_car.workspace = true
+jsonrpc-v2.workspace = true
+libp2p-bitswap.workspace = true
+metrics.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+surf.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 ursa-metrics = { path = "../ursa-metrics" }
 ursa-store = { path = "../ursa-store" }
 ursa-utils = { path = "../ursa-utils" }
-
-[dependencies.libipld]
-version = "0.14.0"
-default-features = false
+libipld.workspace = true
 
 [dependencies.libp2p]
-version = "0.50.0"
+workspace = true
 default-features = false
 features = [
     "autonat",
@@ -66,6 +62,6 @@ features = [
 ]
 
 [dev-dependencies]
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-simple_logger = "2.1.0"
-tokio = { version = "1.20.1", features = ["full"] }
+db.workspace = true
+simple_logger.workspace = true
+tokio.workspace = true

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -9,12 +9,12 @@ mod tests {
     use anyhow::Result;
     use async_fs::File;
     use bytes::Bytes;
-    use cid::Cid;
+    use cid::{Cid, multihash::Code };
     use db::MemoryDB;
     use futures::io::BufReader;
     use futures::StreamExt;
     use fvm_ipld_car::{load_car, CarReader};
-    use libipld::{cbor::DagCborCodec, ipld, multihash::Code, Block, DefaultParams, Ipld};
+    use libipld::{cbor::DagCborCodec, ipld, Block, DefaultParams, Ipld};
     use libp2p::request_response::RequestResponseEvent;
     use libp2p::{
         gossipsub::IdentTopic as Topic, identity::Keypair, multiaddr::Protocol, swarm::SwarmEvent,

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -9,7 +9,7 @@ mod tests {
     use anyhow::Result;
     use async_fs::File;
     use bytes::Bytes;
-    use cid::{Cid, multihash::Code };
+    use cid::{multihash::Code, Cid};
     use db::MemoryDB;
     use futures::io::BufReader;
     use futures::StreamExt;

--- a/crates/ursa-rpc-client/Cargo.toml
+++ b/crates/ursa-rpc-client/Cargo.toml
@@ -8,20 +8,17 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's rpc client implementation"
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.53"
-cid = "0.8.6"
-jsonrpc-v2 = "0.11.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.81"
-simple_logger = "2.1.0"
-surf = { version = "2.3", default-features = true, features = ["curl-client"] }
-tokio = { version = "1.19.2", features = ["rt", "net", "macros", "sync"] }
-tracing = "0.1.35"
+anyhow.workspace = true
+async-trait.workspace = true
+cid.workspace = true
+jsonrpc-v2.workspace = true
+libipld.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+simple_logger.workspace = true
+surf.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 ursa-network = { path = "../ursa-network" }
 ursa-rpc-server = { path = "../ursa-rpc-server" }
 ursa-utils ={ path = "../ursa-utils" }
-
-[dependencies.libipld]
-version = "0.14.0"
-default-features = false

--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -133,11 +133,10 @@ mod tests {
 
     use crate::functions::{get_block, put_file};
 
-    use cid::Cid;
+    use cid::{Cid, multihash::Code};
     use libipld::block::Block;
     use libipld::cbor::DagCborCodec;
     use libipld::ipld::Ipld;
-    use libipld::multihash::Code;
     use libipld::store::DefaultParams;
     use ursa_rpc_server::api::{NetworkGetParams, NetworkPutFileParams};
     use ursa_utils::convert_cid;

--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
 
     use crate::functions::{get_block, put_file};
 
-    use cid::{Cid, multihash::Code};
+    use cid::{multihash::Code, Cid};
     use libipld::block::Block;
     use libipld::cbor::DagCborCodec;
     use libipld::ipld::Ipld;

--- a/crates/ursa-rpc-server/Cargo.toml
+++ b/crates/ursa-rpc-server/Cargo.toml
@@ -36,10 +36,6 @@ ursa-network = { path = "../ursa-network" }
 ursa-store = { path = "../ursa-store" }
 ursa-utils = { path = "../ursa-utils" }
 
-
-[dev-dependencies]
-db.workspace = true
-
 [dependencies.libp2p]
 workspace = true
 default-features = false

--- a/crates/ursa-rpc-server/Cargo.toml
+++ b/crates/ursa-rpc-server/Cargo.toml
@@ -8,41 +8,40 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's multiplex server implementation"
 
 [dependencies]
-anyhow = "1.0.56"
-async-fs = "1.6.0"
-async-trait = "0.1.53"
-axum = { version = "0.5.7", features = ["multipart", "headers"] }
-bytes = "1.1.0"
-cid = "0.8.6"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-fnv = "1.0.7"
-futures = "0.3.21"
-fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_car = "0.5.0"
-hyper = "0.14.20"
-jsonrpc-v2 = "0.11.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.81"
-simple_logger = "2.1.0"
-tokio = { version = "1.20.1", features = ["rt", "net", "macros", "sync"] }
-tokio-util = { version = "0.7", features = ["io", "compat"] }
-tower = "0.4.13"
-tracing = "0.1.33"
+anyhow.workspace = true
+async-fs.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+tracing-subscriber.workspace = true
+bytes.workspace = true
+cid.workspace = true
+db.workspace = true
+fnv.workspace = true
+futures.workspace = true
+fvm_ipld_blockstore.workspace = true
+fvm_ipld_car.workspace = true
+hyper.workspace = true
+jsonrpc-v2.workspace = true
+libipld.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+simple_logger.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tracing.workspace = true
+tokio-util.workspace = true
 ursa-index-provider = { path = "../ursa-index-provider" }
 ursa-metrics = { path = "../ursa-metrics" }
 ursa-network = { path = "../ursa-network" }
 ursa-store = { path = "../ursa-store" }
 ursa-utils = { path = "../ursa-utils" }
 
-[dependencies.libipld]
-version = "0.14.0"
-default-features = false
 
 [dev-dependencies]
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
+db.workspace = true
 
 [dependencies.libp2p]
-version = "0.50.0"
+workspace = true
 default-features = false
 features = [
     "identify",

--- a/crates/ursa-rpc-server/src/http/routes/network.rs
+++ b/crates/ursa-rpc-server/src/http/routes/network.rs
@@ -42,13 +42,13 @@ impl IntoResponse for NetworkError {
 }
 
 pub async fn upload_handler<S>(
-    mut buf: Multipart,
     Extension(interface): Extension<Arc<NodeNetworkInterface<S>>>,
-) -> impl IntoResponse
+    mut buf: Multipart,
+) -> Result<impl IntoResponse, NetworkError>
 where
     S: Blockstore + Store + Send + Sync + 'static,
 {
-    let upload_task = task::spawn(async move {
+    // let upload_task = task::spawn(async move {
         info!("uploading file via http");
         if let Some(field) = buf.next_field().await.unwrap() {
             let content_type = field.content_type().unwrap().to_string();
@@ -60,27 +60,27 @@ where
                 match interface.put_car(reader).await {
                     Err(err) => {
                         error!("{:?}", err);
-                        (
+                        Ok((
                             StatusCode::INTERNAL_SERVER_ERROR,
                             Json(format!("{:?}", err)),
-                        )
+                        ))
                     }
-                    Ok(res) => (StatusCode::OK, Json(format!("{:?}", res))),
+                    Ok(res) => Ok((StatusCode::OK, Json(format!("{:?}", res)))),
                 }
             } else {
-                (
+                Ok((
                     StatusCode::BAD_REQUEST,
                     Json("Content type do not match. Only .car files can be uploaded".to_string()),
-                )
+                ))
             }
         } else {
-            (StatusCode::BAD_REQUEST, Json("No files found".to_string()))
+            Ok((StatusCode::BAD_REQUEST, Json("No files found".to_string())))
         }
-    });
-    match upload_task.await {
-        Ok(res) => res,
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e.to_string())),
-    }
+    // });
+    // match upload_task.await {
+    //     Ok(res) => res,
+    //     Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e.to_string())),
+    // }
 }
 
 pub async fn get_handler<S>(

--- a/crates/ursa-rpc-server/src/rpc/rpc.rs
+++ b/crates/ursa-rpc-server/src/rpc/rpc.rs
@@ -28,8 +28,8 @@ impl IntoResponse for ServerErrors {
 }
 
 pub async fn rpc_handler(
-    Json(req): Json<RequestObject>,
     Extension(server): Extension<RpcServer>,
+    Json(req): Json<RequestObject>,
 ) -> Result<Json<ResponseObjects>, ServerErrors> {
     match server.0.handle(req).await {
         ResponseObjects::One(r) => match r {

--- a/crates/ursa-store/Cargo.toml
+++ b/crates/ursa-store/Cargo.toml
@@ -9,19 +9,19 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's store implementation"
 
 [dependencies]
-anyhow = "1.0.65"
-async-trait = "0.1.56"
-cid = "0.8.6"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-fnv = "1.0.7"
-fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
-libipld = "0.14.0"
-libp2p-bitswap = "0.25.0"
-serde = { version = "1.0", features = ["derive"] }
-simple_logger = "2.2.0"
-tokio = { version = "1.20.1", features = ["full"] }
-tracing = "0.1.35"
+anyhow.workspace = true
+async-trait.workspace = true
+cid.workspace = true
+db.workspace = true
+fnv.workspace = true
+fvm_ipld_blockstore.workspace = true
+fvm_ipld_encoding.workspace = true
+libipld.workspace = true
+libp2p-bitswap.workspace = true
+serde.workspace = true
+simple_logger.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 ursa-utils = { path = "../ursa-utils" }
 
 [features]

--- a/crates/ursa/Cargo.toml
+++ b/crates/ursa/Cargo.toml
@@ -8,21 +8,21 @@ repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's cli"
 
 [dependencies]
-anyhow = "1.0.57"
-ctrlc = "3.1"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-dirs = "4"
-dotenv = "0.15.0"
-futures = "0.3.21"
-libp2p = { version = "0.50.0", default-features = false, features = ["identify", "serde"] }
-pem = "1.1.0"
-resolve-path = "0.1.0"
-serde = { version = "1.0", features = ["derive"] }
-structopt = "0.3"
-tokio = { version = "1.20.1", features = ["full"] }
-toml = "0.5"
-tracing = "0.1.33"
-tracing-subscriber = "0.3.11"
+anyhow.workspace = true
+ctrlc.workspace = true
+db.workspace = true
+dirs.workspace = true
+dotenv.workspace = true
+futures.workspace = true
+libp2p = { workspace = true, default-features = false, features = ["identify", "serde"] }
+pem.workspace = true
+resolve-path.workspace = true
+serde.workspace = true
+structopt.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 ursa-index-provider = { path = "../ursa-index-provider" }
 ursa-metrics = { path = "../ursa-metrics" }
 ursa-network = { path = "../ursa-network" }


### PR DESCRIPTION
motivation: A few of the dependencies in multiple crates were using different versions. Recently, [the dependency inheritance](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace) was added to cargo. so this would be a good way of managing dependencies and update them faster as we move on.