### PR TITLE
feat: add option to specify the port for cli rpc requests

### DIFF
--- a/crates/ursa-rpc-client/src/functions.rs
+++ b/crates/ursa-rpc-client/src/functions.rs
@@ -23,6 +23,9 @@ pub async fn get_file(params: NetworkGetFileParams, rpc_port: Option<u16>) -> Re
     call(NETWORK_GET_FILE, params, Put, rpc_port).await
 }
 
-pub async fn put_file(params: NetworkPutFileParams, rpc_port: Option<u16>) -> Result<NetworkPutFileResult> {
+pub async fn put_file(
+    params: NetworkPutFileParams,
+    rpc_port: Option<u16>,
+) -> Result<NetworkPutFileResult> {
     call(NETWORK_PUT_FILE, params, Put, rpc_port).await
 }

--- a/crates/ursa-rpc-client/src/functions.rs
+++ b/crates/ursa-rpc-client/src/functions.rs
@@ -16,13 +16,13 @@ use crate::{
 pub type Result<T> = anyhow::Result<T, Error>;
 
 pub async fn get_block(params: NetworkGetParams) -> Result<NetworkGetResult> {
-    call(NETWORK_GET, params, Post).await
+    call(NETWORK_GET, params, Post, None).await
 }
 
-pub async fn get_file(params: NetworkGetFileParams) -> Result<()> {
-    call(NETWORK_GET_FILE, params, Put).await
+pub async fn get_file(params: NetworkGetFileParams, rpc_port: Option<u16>) -> Result<()> {
+    call(NETWORK_GET_FILE, params, Put, rpc_port).await
 }
 
-pub async fn put_file(params: NetworkPutFileParams) -> Result<NetworkPutFileResult> {
-    call(NETWORK_PUT_FILE, params, Put).await
+pub async fn put_file(params: NetworkPutFileParams, rpc_port: Option<u16>) -> Result<NetworkPutFileResult> {
+    call(NETWORK_PUT_FILE, params, Put, rpc_port).await
 }

--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         let params = NetworkPutFileParams {
             path: "./car_files/ursa_major.car".to_string(),
         };
-        match put_file(params).await {
+        match put_file(params, None).await {
             Ok(v) => {
                 println!("Put car file done: {v:?}");
             }

--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -36,7 +36,7 @@ pub enum RpcMethod {
 }
 
 /// Utility method for sending RPC requests over HTTP
-async fn call<P, R>(method_name: &str, params: P, method: RpcMethod) -> Result<R, Error>
+async fn call<P, R>(method_name: &str, params: P, method: RpcMethod, rpc_port: Option<u16>) -> Result<R, Error>
 where
     P: Serialize,
     R: DeserializeOwned,
@@ -48,7 +48,10 @@ where
             .with_id(1)
             .finish();
 
-        let ServerConfig { port, addr } = ServerConfig::default();
+        let ServerConfig { mut port, addr } = ServerConfig::default();
+        if let Some(rpc_port) = rpc_port {
+            port = rpc_port;
+        }
         let api_url = format!("http://{addr}:{port}/rpc/v0");
 
         info!("Using JSON-RPC v2 HTTP URL: {api_url}");

--- a/crates/ursa-rpc-client/src/lib.rs
+++ b/crates/ursa-rpc-client/src/lib.rs
@@ -36,7 +36,12 @@ pub enum RpcMethod {
 }
 
 /// Utility method for sending RPC requests over HTTP
-async fn call<P, R>(method_name: &str, params: P, method: RpcMethod, rpc_port: Option<u16>) -> Result<R, Error>
+async fn call<P, R>(
+    method_name: &str,
+    params: P,
+    method: RpcMethod,
+    rpc_port: Option<u16>,
+) -> Result<R, Error>
 where
     P: Serialize,
     R: DeserializeOwned,

--- a/crates/ursa/src/ursa/mod.rs
+++ b/crates/ursa/src/ursa/mod.rs
@@ -36,7 +36,7 @@ pub struct Cli {
     pub cmd: Option<Subcommand>,
 }
 
-#[derive(StructOpt)]
+#[derive(StructOpt, Debug)]
 pub enum Subcommand {
     #[structopt(name = "rpc", about = "run rpc commands from cli")]
     Rpc(RpcCommands),

--- a/crates/ursa/src/ursa/rpc_commands.rs
+++ b/crates/ursa/src/ursa/rpc_commands.rs
@@ -9,6 +9,8 @@ pub enum RpcCommands {
     Put {
         #[structopt(about = "The path to the file")]
         path: String,
+        #[structopt(long, about = "port where the request will be sent")]
+        port: Option<u16>,
     },
     #[structopt(
         about = "get the file from network for a given root cid and store it on given path"
@@ -16,19 +18,21 @@ pub enum RpcCommands {
     Get {
         #[structopt(about = "root cid to get the file")]
         cid: String,
-        #[structopt(about = "The path to sotre the file")]
+        #[structopt(about = "The path to store the file")]
         path: String,
+        #[structopt(long, about = "port where the request will be sent")]
+        port: Option<u16>,
     },
 }
 
 impl RpcCommands {
     pub async fn run(&self) {
         match self {
-            Self::Put { path } => {
+            Self::Put { path, port } => {
                 let params = NetworkPutFileParams {
                     path: path.to_string(),
                 };
-                match put_file(params).await {
+                match put_file(params, *port).await {
                     Ok(file) => {
                         info!("Put car file done: {:?}", file);
                     }
@@ -37,12 +41,12 @@ impl RpcCommands {
                     }
                 };
             }
-            Self::Get { cid, path } => {
+            Self::Get { cid, path, port } => {
                 let params = NetworkGetFileParams {
                     path: path.to_string(),
                     cid: cid.to_string(),
                 };
-                match get_file(params).await {
+                match get_file(params, *port).await {
                     Ok(_result) => {
                         info!("file stored at {path:?}");
                     }


### PR DESCRIPTION
This adds the option to specify the port for cli rpc requests. Sending rpc requests to different ports is useful for developing and debugging. This change is backwards compatible.
For example, to send a put request to port 4071:
```
ursa rpc put <file> --port 4071
```
Without the `--port` option, the port for the request will be taken from [here](https://github.com/fleek-network/ursa/blob/main/crates/ursa-rpc-server/src/config.rs), as before:
```
ursa rpc put <file>
```
