### PR TITLE
feat(ursa): `--log, -l <level>` cli opt, fallback, and default

### DIFF
--- a/crates/ursa/src/ursa/mod.rs
+++ b/crates/ursa/src/ursa/mod.rs
@@ -16,6 +16,7 @@ use std::{
 };
 use structopt::StructOpt;
 use tracing::{error, warn};
+use tracing_subscriber::filter::LevelFilter;
 
 pub mod identity;
 mod rpc_commands;
@@ -50,6 +51,12 @@ pub struct CliOpts {
     pub rpc: bool,
     #[structopt(short = "p", long, help = "Port used for JSON-RPC communication")]
     pub rpc_port: Option<u16>,
+    #[structopt(
+        short,
+        long,
+        help = "Set logging level: info (default), error, warn, debug, trace"
+    )]
+    pub log: Option<LevelFilter>,
 }
 
 impl CliOpts {


### PR DESCRIPTION
## Why

Ursa bin is not consistently setting a default log level and thus requires some to set it locally. This makes the default, and further tweaking the level, much easier and mimicking the [functionality from the gateway](https://github.com/fleek-network/ursa/blob/main/crates/ursa-gateway/src/cli.rs#L12-L14).

## What

- Add `--log, -l <level>` cli opt
- use cli opt, fallback to RUST_LOG, and finally use `info` as default

## Demo

![image](https://user-images.githubusercontent.com/8976745/208836490-d1524968-6a49-4ad8-a58f-0160d3e3f2aa.png)
