### PR TITLE
fix(global metrics): provide `grafana.ini` config directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ domain = "provider.ursa.earth"
 indexer_url = "https://dev.cid.contact"
 database_path = "~/.ursa/data/index_provider_db"
 
-[metrics_config]
-port = "4070"
-
 [server_config]
 port = 4069
 addr = "0.0.0.0"

--- a/infra/global-metrics/docker-compose.yml
+++ b/infra/global-metrics/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
+    command: --config=/var/lib/grafana/grafana.ini
     restart: unless-stopped
     ports:
       - "3000:3000"


### PR DESCRIPTION
Docker compose grafana instance is looking for `grafana.ini` at `/etc/grafana/`. We link the global-metrics grafana data to `/var/lib/grafana/`, so should specify the config location to that path to correctly load it.

Also slipped in a small doc update that was left out from #81 (remove `metrics_config` from readme example config)