### PR TITLE
fix(tracker): dockerfile running in incorrect workdir

### DIFF
--- a/infra/global-metrics/Dockerfile
+++ b/infra/global-metrics/Dockerfile
@@ -19,6 +19,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM debian:bullseye-slim
 
+WORKDIR /root
+
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     && apt-get clean \
@@ -26,8 +28,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists*
 
 # Get compiled binaries from builder's cargo install directory
-COPY --from=builder /usr/src/app/ /
+COPY --from=builder /usr/src/app/ .
 
 # run ursa node
 ENV RUST_LOG=info
-ENTRYPOINT ["/ursa-tracker"]
+ENTRYPOINT ["./ursa-tracker"]


### PR DESCRIPTION
## Why

Dockerfile used `/` as workdir instead of `/root` resulting in rocks using `/tracker_db` instead of the linked volume `/root/tracker_db`. 

## What

- update paths in tracker dockerfile

## Demo

![image](https://user-images.githubusercontent.com/8976745/208968862-6cc23b9a-ceaf-4033-9ed5-eb7c748449ff.png)
