### PR TITLE
fix: make docker-run persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ docker-build:
 docker-run:
 	docker run --name ursa-cli \
 		-p 4069:4069 -p 6009:6009 -p 8070:8070 \
-		-v ~/.ursa:~/.ursa -it ursa
+		-v ~/.ursa:/root/.ursa -it ursa
 
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ docker-build:
 	docker build -t ursa -f ./Dockerfile .
 
 docker-run:
-	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 -p 8070:8070 --name ursa-cli -it ursa
+	docker run --name ursa-cli \
+		-p 4069:4069 -p 6009:6009 -p 8070:8070 \
+		-v ~/.ursa:~/.ursa -it ursa
 
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -14,7 +14,6 @@ async-trait.workspace = true
 bytes.workspace = true
 cid.workspace = true
 db.workspace = true
-dirs.workspace = true
 fnv.workspace = true
 futures.workspace = true
 futures-util.workspace = true

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -8,8 +8,8 @@ pub const DEFAULT_BOOTSTRAP: [&str; 2] = [
     "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p",
     "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM",
 ];
-pub const DEFAULT_DB_PATH_STR: &str = ".ursa/data/ursa_db";
-pub const DEFAULT_KEYSTORE_PATH_STR: &str = ".ursa/keystore";
+pub const DEFAULT_DB_PATH_STR: &str = "~/.ursa/data/ursa_db";
+pub const DEFAULT_KEYSTORE_PATH_STR: &str = "~/.ursa/keystore";
 
 /// Ursa Configuration
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -58,12 +58,10 @@ impl Default for NetworkConfig {
                 "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
                 "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap(),
             ],
-            database_path: home_dir().unwrap_or_default().join(DEFAULT_DB_PATH_STR),
+            database_path: DEFAULT_DB_PATH_STR.parse().unwrap(),
             identity: "default".to_string(),
             tracker: DEFAULT_TRACKER_URL.into(),
-            keystore_path: home_dir()
-                .unwrap_or_default()
-                .join(DEFAULT_KEYSTORE_PATH_STR),
+            keystore_path: DEFAULT_KEYSTORE_PATH_STR.parse().unwrap(),
         }
     }
 }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -1,4 +1,3 @@
-use dirs::home_dir;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;


### PR DESCRIPTION
## Why?

#176 

## What?

- add `-v ~/.ursa:/root/.ursa` to make script to launch docker with persistence
- refactor config default to use `~` and parse later vs `home_dir()` directly. This eases config compatibility when running the node directly vs in docker