### PR TITLE
fix: advertise server address

### DIFF
--- a/crates/ursa-index-provider/src/tests/mod.rs
+++ b/crates/ursa-index-provider/src/tests/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::{config::ProviderConfig, engine::ProviderEngine};
 use db::MemoryDB;
-use libp2p::{identity::Keypair, PeerId};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use simple_logger::SimpleLogger;
 use tracing::{info, log::LevelFilter};
 use ursa_network::{NetworkConfig, UrsaService};
@@ -46,12 +46,15 @@ pub fn provider_engine_init(
 
     let service = UrsaService::new(keypair.clone(), &network_config, Arc::clone(&store))?;
 
+    let server_address = Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap();
+
     let provider_engine = ProviderEngine::new(
         keypair,
         store,
         index_store,
         config,
         service.command_sender(),
+        server_address,
     );
     Ok((provider_engine, service, peer_id))
 }

--- a/crates/ursa-rpc-service/src/tests/mod.rs
+++ b/crates/ursa-rpc-service/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod server_test;
 
 use db::MemoryDB;
 use libp2p::identity::Keypair;
+use libp2p::Multiaddr;
 use simple_logger::SimpleLogger;
 use std::sync::Arc;
 use tracing::{log::LevelFilter, warn};
@@ -38,6 +39,7 @@ pub fn init() -> InitResult {
     network_config.swarm_addrs = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
     let keypair = Keypair::generate_ed25519();
     let service = UrsaService::new(keypair.clone(), &network_config, Arc::clone(&store))?;
+    let server_address = Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap();
 
     let provider_engine = ProviderEngine::new(
         keypair,
@@ -45,6 +47,7 @@ pub fn init() -> InitResult {
         get_store(),
         ProviderConfig::default(),
         service.command_sender(),
+        server_address,
     );
 
     Ok((service, provider_engine, store))

--- a/crates/ursa/src/main.rs
+++ b/crates/ursa/src/main.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use db::{rocks::RocksDb, rocks_config::RocksDbConfig};
 use dotenv::dotenv;
 use libp2p::multiaddr::Protocol;
+use libp2p::Multiaddr;
 use resolve_path::PathResolveExt;
 use std::env;
 use std::str::FromStr;
@@ -96,6 +97,12 @@ async fn main() -> Result<()> {
                 )
                 .expect("Opening provider RocksDB must succeed");
 
+                let server_address = Multiaddr::try_from(format!(
+                    "/ip4/{}/tcp/{}",
+                    server_config.addr, server_config.port
+                ))
+                .expect("Server to have a valid address");
+
                 let index_store = Arc::new(UrsaStore::new(Arc::clone(&Arc::new(provider_db))));
                 let index_provider_engine = ProviderEngine::new(
                     keypair,
@@ -103,6 +110,7 @@ async fn main() -> Result<()> {
                     index_store,
                     provider_config,
                     service.command_sender(),
+                    server_address,
                 );
 
                 // server setup


### PR DESCRIPTION
Blocks #158 

**Motivation**
The address of the server from which advertised content is retrievable wasn't being advertised.

