### PR TITLE
feat: send cache request to peers after PUT request

### DIFF
--- a/crates/ursa-index-provider/src/tests/mod.rs
+++ b/crates/ursa-index-provider/src/tests/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::{config::ProviderConfig, engine::ProviderEngine};
 use db::MemoryDB;
-use libp2p::{identity::Keypair, PeerId};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use simple_logger::SimpleLogger;
 use tracing::{info, log::LevelFilter};
 use ursa_network::{NetworkConfig, UrsaService};
@@ -46,12 +46,15 @@ pub fn provider_engine_init(
 
     let service = UrsaService::new(keypair.clone(), &network_config, Arc::clone(&store))?;
 
+    let server_address = Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap();
+
     let provider_engine = ProviderEngine::new(
         keypair,
         store,
         index_store,
         config,
         service.command_sender(),
+        server_address,
     );
     Ok((provider_engine, service, peer_id))
 }

--- a/crates/ursa-network/src/codec/protocol.rs
+++ b/crates/ursa-network/src/codec/protocol.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use cid::Cid;
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use libp2p::{
     core::{
@@ -34,6 +35,7 @@ pub struct UrsaExchangeCodec;
 pub enum RequestType {
     // change this to the final cid version
     CarRequest(String),
+    CacheRequest(Cid),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -438,10 +438,10 @@ mod tests {
         setup_logger(LevelFilter::Info);
         let mut config = NetworkConfig::default();
 
-        let (mut node_1, node_1_addrs, peer_id_1, store_1) =
+        let (mut node_1, node_1_addrs, peer_id_1, _store_1) =
             network_init(&mut config, None, None).await?;
-        let (mut node_2, node_2_addrs, peer_id_2, store_2) =
-            network_init(&mut config, Some(node_1_addrs.to_string()), None).await?;
+        let (mut node_2, _node_2_addrs, _peer_id_2, _store_2) =
+            network_init(&mut config, Some(node_1_addrs), None).await?;
 
         // Wait for at least one connection
         loop {
@@ -465,14 +465,13 @@ mod tests {
 
         loop {
             if let SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(
-                RequestResponseEvent::Message { peer, message },
-            )) = timeout(Duration::from_secs(10), node_2.swarm.select_next_some())
+                                             RequestResponseEvent::Message { peer, message },
+                                         )) = timeout(Duration::from_secs(5), node_2.swarm.select_next_some())
                 .await
                 .expect("event to be received")
             {
                 info!("[RequestResponseEvent::Message]: {peer:?}, {message:?}");
                 if let RequestResponseMessage::Request {
-                    request_id,
                     request,
                     ..
                 } = message

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -456,7 +456,7 @@ mod tests {
         let node_1_sender = node_1.command_sender();
         tokio::task::spawn(async move { node_1.start().await.unwrap() });
 
-        let (sender, receiver) = oneshot::channel();
+        let (sender, _) = oneshot::channel();
         let request = NetworkCommand::Put {
             cid: Cid::default(),
             sender,

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -217,6 +217,18 @@ where
         info!("The inserted cids are: {cids:?}");
 
         let (sender, receiver) = oneshot::channel();
+        let request = NetworkCommand::Put {
+            cid: root_cid,
+            sender,
+        };
+        self.network_send.send(request)?;
+        if let Err(e) = receiver.await {
+            return Err(anyhow!(format!(
+                "The PUT failed, please check server logs {e:?}"
+            )));
+        }
+
+        let (sender, receiver) = oneshot::channel();
         let request = ProviderCommand::Put {
             context_id: root_cid.to_bytes(),
             sender,

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -223,9 +223,8 @@ where
         };
         self.network_send.send(request)?;
         if let Err(e) = receiver.await {
-            return Err(anyhow!(format!(
-                "The PUT failed, please check server logs {e:?}"
-            )));
+            bail!("The PUT failed, please check server logs {e:?}");
+
         }
 
         let (sender, receiver) = oneshot::channel();

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -223,8 +223,7 @@ where
         };
         self.network_send.send(request)?;
         if let Err(e) = receiver.await {
-            bail!("The PUT failed, please check server logs {e:?}");
-
+            anyhow::bail!("The PUT failed, please check server logs {e:?}");
         }
 
         let (sender, receiver) = oneshot::channel();

--- a/crates/ursa-rpc-service/src/tests/mod.rs
+++ b/crates/ursa-rpc-service/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod server_test;
 
 use db::MemoryDB;
 use libp2p::identity::Keypair;
+use libp2p::Multiaddr;
 use simple_logger::SimpleLogger;
 use std::sync::Arc;
 use tracing::{log::LevelFilter, warn};
@@ -38,6 +39,7 @@ pub fn init() -> InitResult {
     network_config.swarm_addrs = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
     let keypair = Keypair::generate_ed25519();
     let service = UrsaService::new(keypair.clone(), &network_config, Arc::clone(&store))?;
+    let server_address = Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap();
 
     let provider_engine = ProviderEngine::new(
         keypair,
@@ -45,6 +47,7 @@ pub fn init() -> InitResult {
         get_store(),
         ProviderConfig::default(),
         service.command_sender(),
+        server_address,
     );
 
     Ok((service, provider_engine, store))

--- a/crates/ursa-tracker/src/ip_api.rs
+++ b/crates/ursa-tracker/src/ip_api.rs
@@ -37,7 +37,7 @@ pub async fn get_ip_info(token: String, addr: String) -> Result<IpInfoResponse> 
         addr.clone()
     };
 
-    let url = format!("https://ipinfo.io/{ip}?{token}");
+    let url = format!("https://ipinfo.io/{ip}?token={token}");
     let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
 
     let res = client.get(url.parse()?).await?;

--- a/crates/ursa/src/main.rs
+++ b/crates/ursa/src/main.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use db::{rocks::RocksDb, rocks_config::RocksDbConfig};
 use dotenv::dotenv;
 use libp2p::multiaddr::Protocol;
+use libp2p::Multiaddr;
 use resolve_path::PathResolveExt;
 use std::env;
 use std::str::FromStr;
@@ -96,6 +97,12 @@ async fn main() -> Result<()> {
                 )
                 .expect("Opening provider RocksDB must succeed");
 
+                let server_address = Multiaddr::try_from(format!(
+                    "/ip4/{}/tcp/{}",
+                    server_config.addr, server_config.port
+                ))
+                .expect("Server to have a valid address");
+
                 let index_store = Arc::new(UrsaStore::new(Arc::clone(&Arc::new(provider_db))));
                 let index_provider_engine = ProviderEngine::new(
                     keypair,
@@ -103,6 +110,7 @@ async fn main() -> Result<()> {
                     index_store,
                     provider_config,
                     service.command_sender(),
+                    server_address,
                 );
 
                 // server setup


### PR DESCRIPTION
Each node is responsible for replicating its cached content onto its connected peers. After receiving a PUT request, a node will send a caching request to its connected peers.