### PR TITLE
refactor(kad): start initial bootstrap from behaviour.rs sooner + improve logs

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -200,6 +200,16 @@ impl<P: StoreParams> Behaviour<P> {
             }
         }
 
+        if !config.bootstrapper && !config.bootstrap_nodes.is_empty() {
+            if let Err(e) = kad.bootstrap() {
+                warn!("Failed to bootstrap: {}", e);
+            } else {
+                info!("Bootstrapping into the network...");
+            }
+        } else {
+            warn!("Skipping bootstrap");
+        }
+
         Behaviour {
             ping,
             autonat,
@@ -231,10 +241,6 @@ impl<P: StoreParams> Behaviour<P> {
 
     pub fn public_address(&self) -> Option<&Multiaddr> {
         self.autonat.as_ref().and_then(|a| a.public_address())
-    }
-
-    pub fn bootstrap(&mut self) -> Result<libp2p::kad::QueryId> {
-        self.kad.bootstrap().map_err(|e| e.into())
     }
 
     pub fn subscribe(&mut self, topic: &Topic) -> Result<bool, SubscriptionError> {

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -274,12 +274,6 @@ where
         let (event_sender, _event_receiver) = unbounded_channel();
         let (command_sender, command_receiver) = unbounded_channel();
 
-        if !config.bootstrapper && !config.bootstrap_nodes.is_empty() {
-            if let Err(e) = swarm.behaviour_mut().bootstrap() {
-                warn!("Failed to bootstrap: {}", e);
-            }
-        }
-
         Ok(UrsaService {
             swarm,
             store,


### PR DESCRIPTION
start the bootstrap sooner, currently getting an error bootstrap timed out with no more bootstraps remaining. This seems to fix that getting 8+ bootstraps remaining after the first one instead of none. 

Manually tested + unit tested, there are still some timeouts but the bootstrap keeps going. While the bootstrap are returning some odd peer ids (`1AdivKqEdvpxsBm1yQjTRYbqk7MdfVjRmQAzxm752XQVZ6` vs our peer ids which always look like: `12D3KooWN2GSWDQwtRWsgiYXDgCHX5scrdHQPman3tBH2WtyCyK3`), it seems to be working. during the time it took to get to the final bootstrap response, the node had peer connection events for 30+ new peers. I think some timeouts are from peers that had id's switch and are no longer available at the /p2p/<id> address that might still persist in some routing tables

tldr; improves boostrapping consistency by starting it sooner, and new peers are flooding in.
