### PR TITLE
fix(metrics): ensure all swarm metrics are recorded

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -573,6 +573,8 @@ where
 
     /// Handle swarm events
     pub fn handle_swarm_event(&mut self, event: SwarmEventType) -> Result<()> {
+        // record basic swarm metrics
+        event.record();
         match event {
             SwarmEvent::Behaviour(event) => match event {
                 BehaviourEvent::Identify(identify_event) => {
@@ -627,7 +629,6 @@ where
                 Ok(())
             }
             _ => {
-                event.record();
                 debug!("Unhandled swarm event {:?}", event);
                 Ok(())
             }


### PR DESCRIPTION
Some swarm metrics are being missed due to the record happening in the catchall in the match. Since #180 ConnectionEstablished/Closed are handled there, so they were not longer getting recorded. This puts the swarm event record call first, so there's no chance of missing metrics

(paired with #190 we now have some nice numbers for connected peers)
![image](https://user-images.githubusercontent.com/8976745/209423375-0460df7d-2958-4888-b5fa-e54ac96400b7.png)