### PR TITLE
feat: `make compose-build` + only build ursa binary in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,38 @@
-FROM rust:latest AS rust
+FROM rust:latest as builder
 
-# setup build environment
-WORKDIR /app
-RUN cargo install cargo-chef
-RUN cargo install cargo-strip
+WORKDIR /usr/src/app
+
 RUN apt-get update && apt-get install -y \
     clang \
     cmake \
     libclang-dev \
     protobuf-compiler
 
-FROM rust as planner
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo install cargo-strip
 
 COPY . .
-RUN cargo chef prepare  \
-    --recipe-path recipe.json
 
-FROM rust as builder
-
-# build dependencies
-COPY --from=planner /app/recipe.json .
-RUN cargo chef cook \
-    --recipe-path recipe.json \
-    --bin ursa --release
-
-# build application
-COPY . .
 ENV RUST_BACKTRACE=1
-RUN cargo build --bin ursa --release && \
-    cargo strip && \
-    mv ./target/*/ursa .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/src/app/target \
+    cargo build --release --bin ursa \
+    && cargo strip \
+    && mv /usr/src/app/target/release/ursa /usr/src/app/
 
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev \
-    && apt-get clean && apt-get purge -y \
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    && apt-get clean \
+    && apt-get purge -y \
     && rm -rf /var/lib/apt/lists*
 
 # Get compiled binaries from builder's cargo install directory
-COPY --from=builder /app/ursa /usr/local/bin
+COPY --from=builder /usr/src/app/ursa /usr/local/bin
 
 # run ursa node
+ENV RUST_LOG=info
+
 ENTRYPOINT ["ursa"]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ docker-build:
 docker-run:
 	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 -p 8070:8070 --name ursa-cli -it ursa
 
+compose-build:
+	docker-compose -f infra/ursa/docker-compose.yml build
+
 compose-up:
 	docker-compose -f infra/ursa/docker-compose.yml up
 


### PR DESCRIPTION
## Why?

- Sequential docker builds are slower considering cargo builds all dependencies every time from scratch
- the dockerfile is building every single binary found in the project, instead of just the ursa bin specifically.
- no easy make helper to rebuild the docker-compose ursa image 

## What?

Adds [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) caching to our docker file to take advantage of docker layers to not have to build all dependencies from scratch every time. This saves time by several minutes after the first build, so for node operators updating the deploy time is much sooner, as well as reducing build time for node development.

Also adds a new makescript `compose-build` to build ursa binary within the docker-compose context
 
## Demo?

First build:
![image](https://user-images.githubusercontent.com/8976745/209426422-662c101c-b0c4-44a3-a57b-3fc5a6d10d71.png)

Next builds with cached layers:
![image](https://user-images.githubusercontent.com/8976745/209426227-2ab96195-7002-4f57-ba92-4bd916d9f414.png)

