### PR TITLE
feat: send cache request to peers after PUT request

### DIFF
--- a/crates/ursa-network/src/codec/protocol.rs
+++ b/crates/ursa-network/src/codec/protocol.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use cid::Cid;
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use libp2p::{
     core::{
@@ -34,6 +35,7 @@ pub struct UrsaExchangeCodec;
 pub enum RequestType {
     // change this to the final cid version
     CarRequest(String),
+    CacheRequest(Cid),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -56,6 +56,7 @@ use ursa_metrics::Recorder;
 use ursa_store::{BitswapStorage, UrsaStore};
 
 use crate::behaviour::KAD_PROTOCOL;
+use crate::codec::protocol::RequestType;
 use crate::transport::build_transport;
 use crate::{
     behaviour::{Behaviour, BehaviourEvent},
@@ -677,7 +678,17 @@ where
 
                 println!("cosmos");
             }
-            NetworkCommand::Put { cid: _, sender: _ } => (),
+            NetworkCommand::Put { cid, sender } => {
+                let swarm = self.swarm.behaviour_mut();
+                for peer in &self.peers {
+                    swarm
+                        .request_response
+                        .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
+                }
+                sender
+                    .send(Ok(()))
+                    .map_err(|e| anyhow!("PUT failed: {e:?}."))?;
+            }
             NetworkCommand::GetPeers { sender } => {
                 sender
                     .send(self.peers.clone())


### PR DESCRIPTION
Clean version of #186 (will be closed).

**Motivation:**
Each node is responsible for replicating its cached content onto its connected peers. After receiving a PUT request, a node will send a caching request to its connected peers.