### PR TITLE
chore: codecov and job isolation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.make.name }} (${{ matrix.os }})
+    name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
       - run: cargo test --workspace --no-default-features
 
   coverage:
-    name: Tests coverage (${{ matrix.os }})
+    name: Tests coverage
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -124,7 +124,7 @@ jobs:
           file: ${{ steps.coverage.outputs.report }}
 
   clippy:
-    name: Lint with clippy (${{ matrix.os }})
+    name: Lint with clippy
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -170,7 +170,7 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features
 
   rustfmt:
-    name: Code formatting (${{ matrix.os }})
+    name: Code formatting
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: rust-ci
 
+env:
+  RUST_BACKTRACE: 1
+
 on:
   push:
     branches: [ "main" ]
@@ -13,34 +16,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust: [nightly]
-        make:
-          - name: check-fmt-clippy
-            task: "ci"
-          - name: test
-            task: "test"
-          - name: doc
-            task: "doc"
-
-    # env:
-    #   CARGO_INCREMENTAL: '0'
-    #   RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-    #   RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-
+        include:
+          - { rust: stable,           os: ubuntu-latest }
+          - { rust: nightly,          os: macos-latest }
+          - { rust: stable,           os: windows-latest }
+          - { rust: nightly,          os: ubuntu-latest }
     steps:
+      - uses: actions/checkout@master
+
       - name: Install Dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential clang ocl-icd-opencl-dev
-
-      - name: Checkout repository
-        uses: actions/checkout@master
-
-      # - name: Install protoc (ubuntu-latest)
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -48,7 +36,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install protoc (macos-latest)
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
           brew install protobuf
@@ -60,30 +48,164 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
-          components: clippy, rustc-dev, llvm-tools-preview, rustfmt
+          components: rustc-dev, llvm-tools-preview
 
-      - name: Cache Cargo
+      - name: Set up cargo cache
         uses: actions/cache@v3
+        continue-on-error: false
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - run: cargo test --verbose --workspace --all-features
+      - run: cargo test --verbose --workspace --no-default-features
+
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [nightly]
+    env:
+      CARGO_INCREMENTAL: '0'
+      RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+      RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang ocl-icd-opencl-dev
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+          components: clippy
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
           
-      - name: ${{ matrix.make.name }}
-        run: make ${{ matrix.make.task }}
+      - run: cargo test --verbose --workspace --all-features
+      - run: cargo test --verbose --workspace --no-default-features
 
       - name: Setup grcov
-        if: ${{ matrix.make.name == 'test' }}
         id: coverage
         uses: actions-rs/grcov@v0.1
 
       - name: grcov upload to codecov.io
-        if: ${{ matrix.make.name == 'test' }}
         uses: codecov/codecov-action@v3
         with:
           file: ${{ steps.coverage.outputs.report }}
+
+  clippy:
+    name: Lint with clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang ocl-icd-opencl-dev
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+          components: clippy
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - run: cargo clippy --workspace --all-targets --verbose
+      - run: cargo clippy --workspace --all-targets --verbose --no-default-features
+      - run: cargo clippy --workspace --all-targets --verbose --all-features
+
+  rustfmt:
+    name: Verify code formatting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@master
+      
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang ocl-icd-opencl-dev
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+          components: rustfmt
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,15 +11,16 @@ on:
 
 jobs:
   tests:
-    name: ${{ matrix.make.name }} (${{ matrix.os }})
+    name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - { rust: stable,           os: ubuntu-latest }
-          - { rust: nightly,          os: macos-latest }
-          - { rust: stable,           os: windows-latest }
+          - { rust: stable,           os: macos-latest }
+          # - { rust: stable,           os: windows-latest }
+          - { rust: beta,             os: ubuntu-latest }
           - { rust: nightly,          os: ubuntu-latest }
     steps:
       - uses: actions/checkout@master
@@ -63,11 +64,11 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo test --verbose --workspace --all-features
-      - run: cargo test --verbose --workspace --no-default-features
+      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --no-default-features
 
   coverage:
-    name: Test Coverage
+    name: Tests coverage (${{ matrix.os }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -110,8 +111,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
           
-      - run: cargo test --verbose --workspace --all-features
-      - run: cargo test --verbose --workspace --no-default-features
+      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --no-default-features
 
       - name: Setup grcov
         id: coverage
@@ -123,7 +124,7 @@ jobs:
           file: ${{ steps.coverage.outputs.report }}
 
   clippy:
-    name: Lint with clippy
+    name: Lint with clippy (${{ matrix.os }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -164,19 +165,19 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo clippy --workspace --all-targets --verbose
-      - run: cargo clippy --workspace --all-targets --verbose --no-default-features
-      - run: cargo clippy --workspace --all-targets --verbose --all-features
+      - run: cargo clippy --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets --no-default-features
+      - run: cargo clippy --workspace --all-targets --all-features
 
   rustfmt:
-    name: Verify code formatting
+    name: Code formatting (${{ matrix.os }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust: [stable]
     steps:
       - uses: actions/checkout@master
-      
+
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,10 @@ jobs:
           - name: doc
             task: "doc"
 
-    env:
-      CARGO_INCREMENTAL: '0'
-      RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+    # env:
+    #   CARGO_INCREMENTAL: '0'
+    #   RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+    #   RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
     steps:
       - name: Install Dependencies
@@ -78,12 +78,12 @@ jobs:
         run: make ${{ matrix.make.task }}
 
       - name: Setup grcov
-        if: matrix.make == 'test'
+        if: ${{ matrix.make.name == 'test' }}
         id: coverage
         uses: actions-rs/grcov@v0.1
 
       - name: grcov upload to codecov.io
-        if: matrix.make == 'test'
+        if: ${{ matrix.make.name == 'test' }}
         uses: codecov/codecov-action@v3
         with:
           file: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,10 +9,6 @@ on:
   pull_request:
     paths:
       - 'infra/tf-next/**'
-  workflow_run:
-    workflows: ["rust-ci", "docker-build-push"]
-    types:
-      - completed
 
 jobs:
   terraform:
@@ -80,9 +76,9 @@ jobs:
               body: output
             })
       - name: Terraform Plan Status
-        if: ${{  steps.plan.outcome == 'failure' }}
+        if: ${{ steps.plan.outcome == 'failure' }}
         run: exit 1
 
       - name: Terraform Apply
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
         run: terraform apply -auto-approve -input=false

--- a/crates/ursa-index-provider/src/tests/provider_tests.rs
+++ b/crates/ursa-index-provider/src/tests/provider_tests.rs
@@ -52,7 +52,7 @@ mod tests {
             let signed_head: SignedHead = surf::get("http://0.0.0.0:8070/head")
                 .recv_json()
                 .await
-                .map_err(|e| SurfError::into_inner(e))?;
+                .map_err(SurfError::into_inner)?;
             let head_cid = signed_head.open()?.1.to_string();
             assert_eq!(head_cid, provider_interface.head().unwrap().to_string());
             debug!(
@@ -65,7 +65,7 @@ mod tests {
             let data: Vec<u8> = surf::get(format!("http://0.0.0.0:8070/{head_cid}"))
                 .recv_bytes()
                 .await
-                .map_err(|e| SurfError::into_inner(e))?;
+                .map_err(SurfError::into_inner)?;
             let ad: Advertisement = fvm_ipld_encoding::from_slice(&data)?;
             debug!("{ad:?} \n {published_ad:?}");
             assert_eq!(ad, published_ad);

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -180,7 +180,7 @@ pub enum NetworkCommand {
 
 pub struct UrsaService<S> {
     /// Store.
-    store: Arc<UrsaStore<S>>,
+    pub store: Arc<UrsaStore<S>>,
     /// The main libp2p swarm emitting events.
     swarm: Swarm<Behaviour<DefaultParams>>,
     /// Handles outbound messages to peers.

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -349,7 +349,7 @@ mod tests {
 
         match res {
             Ok(_) => {
-                let store_1_block = bitswap_store_2.get(&block.cid()).unwrap();
+                let store_1_block = bitswap_store_2.get(block.cid()).unwrap();
 
                 info!(
                     "inserting block into bitswap store for node 1, {:?}",

--- a/crates/ursa-rpc-service/src/tests/api_test.rs
+++ b/crates/ursa-rpc-service/src/tests/api_test.rs
@@ -32,7 +32,7 @@ mod tests {
             .get_file("../../test_files".to_string(), root_cid)
             .await?;
 
-        let path = format!("../../test_files/{}.car", root_cid.to_string());
+        let path = format!("../../test_files/{root_cid}.car");
         let path = Path::new(&path);
         let file = File::open(path).await?;
         let reader = BufReader::new(file);

--- a/crates/ursa-rpc-service/src/tests/mod.rs
+++ b/crates/ursa-rpc-service/src/tests/mod.rs
@@ -35,8 +35,10 @@ type InitResult = anyhow::Result<(
 
 pub fn init() -> InitResult {
     let store = get_store();
-    let mut network_config = NetworkConfig::default();
-    network_config.swarm_addrs = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
+    let network_config = NetworkConfig {
+        swarm_addrs: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
+        ..Default::default()
+    };
     let keypair = Keypair::generate_ed25519();
     let service = UrsaService::new(keypair.clone(), &network_config, Arc::clone(&store))?;
     let server_address = Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap();

--- a/crates/ursa/src/main.rs
+++ b/crates/ursa/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     TelemetryConfig::new("ursa-cli")
         .with_pretty_log()
         .with_tree_tracer()
-        .with_log_level(opts.log.as_ref().unwrap_or_else(|| &log_level))
+        .with_log_level(opts.log.as_ref().unwrap_or(&log_level))
         .init()?;
 
     match opts.to_config() {


### PR DESCRIPTION
Why?

- [x] Isolate the coverage job and its env vars to not affect other jobs. Especially ones requiring being run nightly. 
- [x] Fix issues surfaced by the linter.
- [x] remove workflow checks for terraform apply on push to main