### PR TITLE
feat: nodes exchange bloom filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ ctrlc = "3.2.4"
 db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
+fasthash = "0.4.0"
 fnv = "1.0.7"
 futures = "0.3.25"
 futures-util = "0.3.25"

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -15,6 +15,7 @@ bytes.workspace = true
 cid.workspace = true
 db.workspace = true
 dirs.workspace = true
+fasthash.workspace = true
 fnv.workspace = true
 futures.workspace = true
 futures-util.workspace = true

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -11,6 +11,7 @@ description = "Ursa's libp2p implementation"
 anyhow.workspace = true
 async-fs.workspace = true
 async-trait.workspace = true
+bincode.workspace = true
 bytes.workspace = true
 cid.workspace = true
 db.workspace = true

--- a/crates/ursa-network/src/lib.rs
+++ b/crates/ursa-network/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 mod gossipsub;
 pub mod service;
 mod transport;
+mod utils;
 
 pub use self::config::*;
 pub use self::service::*;

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -715,7 +715,7 @@ where
                         .request_response
                         .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
                 }
-                // update bloom filter and share it with the network
+                // update cache summary and share it with the network
                 self.cached_content.insert(&cid.to_bytes());
                 let topic = Topic::new(URSA_GLOBAL);
                 if let Ok(cache_summary) = self.cached_content.serialize() {

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -679,12 +679,15 @@ where
                 println!("cosmos");
             }
             NetworkCommand::Put { cid, sender } => {
+                // replicate content
                 let swarm = self.swarm.behaviour_mut();
                 for peer in &self.peers {
                     swarm
                         .request_response
                         .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
                 }
+                // update bloom filter
+
                 sender
                     .send(Ok(()))
                     .map_err(|e| anyhow!("PUT failed: {e:?}."))?;

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -58,6 +58,7 @@ use ursa_store::{BitswapStorage, UrsaStore};
 use crate::behaviour::KAD_PROTOCOL;
 use crate::codec::protocol::RequestType;
 use crate::transport::build_transport;
+use crate::utils::bloom_filter::CountingBloomFilter;
 use crate::{
     behaviour::{Behaviour, BehaviourEvent},
     codec::protocol::{UrsaExchangeRequest, UrsaExchangeResponse},
@@ -176,6 +177,11 @@ pub enum NetworkCommand {
         peer_id: PeerId,
         message: GossipsubMessage,
     },
+
+    #[cfg(test)]
+    GetPeerContent {
+        sender: oneshot::Sender<HashMap<PeerId, CountingBloomFilter>>,
+    },
 }
 
 pub struct UrsaService<S> {
@@ -201,8 +207,14 @@ pub struct UrsaService<S> {
     pending_responses: HashMap<RequestId, oneshot::Sender<Result<UrsaExchangeResponse>>>,
     /// Connected peers.
     peers: HashSet<PeerId>,
-    /// Bootstrap multiaddrs
+    /// Bootstrap multiaddrs.
     bootstraps: Vec<Multiaddr>,
+    /// Summarizes the cached content.
+    cached_content: CountingBloomFilter,
+    /// Content summaries from other nodes.
+    peer_cached_content: HashMap<PeerId, CountingBloomFilter>,
+    /// Blacklisted peers (most interactions will be refused).
+    peer_blacklist: HashSet<PeerId>,
 }
 
 impl<S> UrsaService<S>
@@ -294,6 +306,9 @@ where
             pending_responses: HashMap::default(),
             peers,
             bootstraps: config.bootstrap_nodes.clone(),
+            cached_content: CountingBloomFilter::default(),
+            peer_cached_content: HashMap::default(),
+            peer_blacklist: HashSet::default(),
         })
     }
 
@@ -464,6 +479,21 @@ where
                 message_id,
                 message,
             } => {
+                if !self.peer_blacklist.contains(&propagation_source) {
+                    if let Some(source) = &message.source {
+                        if !self.peer_blacklist.contains(source) {
+                            let message_bytes = &message.data;
+                            if let Ok(cache_summary) =
+                                CountingBloomFilter::deserialize(message_bytes)
+                            {
+                                self.peer_cached_content.insert(*source, cache_summary);
+                            } else {
+                                warn!("[GossipsubEvent::Message] - Failed to deserialize cache summary.");
+                            }
+                        }
+                    }
+                }
+
                 self.emit_event(NetworkEvent::Gossipsub(GossipsubEvent::Message {
                     peer_id: propagation_source,
                     message_id,
@@ -575,6 +605,7 @@ where
     /// Handle swarm events
     pub fn handle_swarm_event(&mut self, event: SwarmEventType) -> Result<()> {
         // record basic swarm metrics
+
         event.record();
         match event {
             SwarmEvent::Behaviour(event) => match event {
@@ -675,8 +706,6 @@ where
                         )
                     }
                 }
-
-                println!("cosmos");
             }
             NetworkCommand::Put { cid, sender } => {
                 // replicate content
@@ -686,7 +715,16 @@ where
                         .request_response
                         .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
                 }
-                // update bloom filter
+                // update bloom filter and share it with the network
+                self.cached_content.insert(&cid.to_bytes());
+                let topic = Topic::new(URSA_GLOBAL);
+                if let Ok(cache_summary) = self.cached_content.serialize() {
+                    if let Err(e) = swarm.publish(topic, Bytes::from(cache_summary)) {
+                        warn!("[NetworkCommand::Put] - Failed to send cached content with error: {e:?}");
+                    };
+                } else {
+                    warn!("[NetworkCommand::Put] - Failed to serialize cached content.");
+                }
 
                 sender
                     .send(Ok(()))
@@ -773,6 +811,12 @@ where
                         .map_err(|_| anyhow!("Failed to publish message!"))?;
                 }
             },
+            #[cfg(test)]
+            NetworkCommand::GetPeerContent { sender } => {
+                sender
+                    .send(self.peer_cached_content.clone())
+                    .map_err(|_| anyhow!("Failed to send peer content."))?;
+            }
         }
         Ok(())
     }

--- a/crates/ursa-network/src/utils/bloom_filter.rs
+++ b/crates/ursa-network/src/utils/bloom_filter.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, Result};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CountingBloomFilter {
     buckets: Vec<u8>,
-    num_hashes: usize
+    num_hashes: usize,
 }
 
 impl CountingBloomFilter {
@@ -24,7 +24,7 @@ impl CountingBloomFilter {
 
     pub fn insert<T: AsRef<[u8]>>(&mut self, value: &T) {
         for i in 0..self.num_hashes {
-            let hash = fasthash::murmur3::hash32_with_seed(&value, i as u32);
+            let hash = fasthash::murmur3::hash32_with_seed(value, i as u32);
             let index = (hash % (self.buckets.len() as u32)) as usize;
             let count = self.buckets.get_mut(index).unwrap();
             *count = count.saturating_add(1);
@@ -47,7 +47,7 @@ impl CountingBloomFilter {
             return Err(anyhow!("Element does not exist."));
         }
         for i in 0..self.num_hashes {
-            let hash = fasthash::murmur3::hash32_with_seed(&value, i as u32);
+            let hash = fasthash::murmur3::hash32_with_seed(value, i as u32);
             let index = (hash % (self.buckets.len() as u32)) as usize;
             let count = self.buckets.get_mut(index).unwrap();
             *count = count.saturating_sub(1);
@@ -70,7 +70,6 @@ impl CountingBloomFilter {
     fn calculate_num_hashes(n: usize, m: usize) -> usize {
         (((m as f64) / (n as f64)) * 2.0f64.ln()).ceil() as usize
     }
-
 }
 
 #[cfg(test)]
@@ -137,5 +136,4 @@ mod tests {
         assert!(filter.contains(&"def"));
         assert!(filter.contains(&"ghi"));
     }
-
 }

--- a/crates/ursa-network/src/utils/bloom_filter.rs
+++ b/crates/ursa-network/src/utils/bloom_filter.rs
@@ -31,6 +31,7 @@ impl CountingBloomFilter {
         }
     }
 
+    #[allow(dead_code)]
     pub fn contains<T: AsRef<[u8]>>(&self, value: &T) -> bool {
         for i in 0..self.num_hashes {
             let hash = fasthash::murmur3::hash32_with_seed(value, i as u32);
@@ -42,6 +43,7 @@ impl CountingBloomFilter {
         true
     }
 
+    #[allow(dead_code)]
     pub fn remove<T: AsRef<[u8]>>(&mut self, value: &T) -> Result<()> {
         if !self.contains(value) {
             return Err(anyhow!("Element does not exist."));

--- a/crates/ursa-network/src/utils/bloom_filter.rs
+++ b/crates/ursa-network/src/utils/bloom_filter.rs
@@ -1,0 +1,141 @@
+use anyhow::{anyhow, Result};
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct CountingBloomFilter {
+    buckets: Vec<u8>,
+    num_hashes: usize
+}
+
+impl CountingBloomFilter {
+    pub fn new(num_elements: usize, fp_rate: f64) -> Self {
+        let num_buckets = Self::calculate_num_buckets(num_elements, fp_rate);
+        let num_hashes = Self::calculate_num_hashes(num_elements, num_buckets);
+
+        CountingBloomFilter {
+            buckets: vec![0; num_buckets],
+            num_hashes,
+        }
+    }
+
+    pub fn default() -> Self {
+        CountingBloomFilter::new(10_000, 0.1)
+    }
+
+    pub fn insert<T: AsRef<[u8]>>(&mut self, value: &T) {
+        for i in 0..self.num_hashes {
+            let hash = fasthash::murmur3::hash32_with_seed(&value, i as u32);
+            let index = (hash % (self.buckets.len() as u32)) as usize;
+            let count = self.buckets.get_mut(index).unwrap();
+            *count = count.saturating_add(1);
+        }
+    }
+
+    pub fn contains<T: AsRef<[u8]>>(&self, value: &T) -> bool {
+        for i in 0..self.num_hashes {
+            let hash = fasthash::murmur3::hash32_with_seed(value, i as u32);
+            let index = (hash % (self.buckets.len() as u32)) as usize;
+            if self.buckets.get(index).unwrap() == &0u8 {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn remove<T: AsRef<[u8]>>(&mut self, value: &T) -> Result<()> {
+        if !self.contains(value) {
+            return Err(anyhow!("Element does not exist."));
+        }
+        for i in 0..self.num_hashes {
+            let hash = fasthash::murmur3::hash32_with_seed(&value, i as u32);
+            let index = (hash % (self.buckets.len() as u32)) as usize;
+            let count = self.buckets.get_mut(index).unwrap();
+            *count = count.saturating_sub(1);
+        }
+        Ok(())
+    }
+
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|_| anyhow!("Failed to serialize bloom filter."))
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> Result<CountingBloomFilter> {
+        bincode::deserialize(bytes).map_err(|_| anyhow!("Failed to deserialize bloom filter."))
+    }
+
+    fn calculate_num_buckets(n: usize, fp_rate: f64) -> usize {
+        ((-(n as f64) * fp_rate.ln()) / (2.0f64.ln().powf(2.0))).ceil() as usize
+    }
+
+    fn calculate_num_hashes(n: usize, m: usize) -> usize {
+        (((m as f64) / (n as f64)) * 2.0f64.ln()).ceil() as usize
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_contains() {
+        let mut filter = CountingBloomFilter::new(5, 0.01);
+        filter.insert(&"abc");
+        filter.insert(&"def");
+        filter.insert(&"ghi");
+        filter.insert(&"jkl");
+        filter.insert(&"mnop");
+
+        assert!(filter.contains(&"abc"));
+        assert!(filter.contains(&"def"));
+        assert!(filter.contains(&"ghi"));
+        assert!(filter.contains(&"jkl"));
+        assert!(filter.contains(&"mnop"));
+
+        assert!(!filter.contains(&"xyz"));
+        assert!(!filter.contains(&"test"));
+        assert!(!filter.contains(&"hallo"));
+        assert!(!filter.contains(&"1234"));
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut filter = CountingBloomFilter::new(5, 0.01);
+        filter.insert(&"xyz");
+        filter.insert(&"fgh");
+        filter.insert(&"hjz");
+        filter.insert(&"dfgh");
+        filter.insert(&"oiuz");
+
+        filter.remove(&"xyz").unwrap();
+        assert!(!filter.contains(&"xyz"));
+
+        filter.remove(&"fgh").unwrap();
+        assert!(!filter.contains(&"fgh"));
+
+        filter.remove(&"hjz").unwrap();
+        assert!(!filter.contains(&"hjz"));
+
+        filter.remove(&"dfgh").unwrap();
+        assert!(!filter.contains(&"dfgh"));
+
+        filter.remove(&"oiuz").unwrap();
+        assert!(!filter.contains(&"oizu"));
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let mut filter = CountingBloomFilter::new(10, 0.01);
+        filter.insert(&"abc");
+        filter.insert(&"def");
+        filter.insert(&"ghi");
+
+        let bytes = filter.serialize().unwrap();
+        let filter = CountingBloomFilter::deserialize(&bytes).unwrap();
+
+        assert!(filter.contains(&"abc"));
+        assert!(filter.contains(&"def"));
+        assert!(filter.contains(&"ghi"));
+    }
+
+}

--- a/crates/ursa-network/src/utils/mod.rs
+++ b/crates/ursa-network/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod bloom_filter;

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -216,6 +216,15 @@ where
 
         info!("The inserted cids are: {cids:?}");
 
+        let (sender, _) = oneshot::channel();
+        let request = NetworkCommand::Put {
+            cid: root_cid,
+            sender,
+        };
+        if let Err(e) = self.network_send.send(request) {
+            error!("There was an error while sending NetworkCommand::Put: {e}");
+        }
+
         let (sender, receiver) = oneshot::channel();
         let request = ProviderCommand::Put {
             context_id: root_cid.to_bytes(),


### PR DESCRIPTION
**Motivation:**
Cache nodes use bloom filters to keep track of the set of objects stored in their cache. Nodes share their bloom filters with the network. Nodes will keep track of the bloom filters that were sent by other nodes. When a requested CID is not in a node's cache, a node can search through the bloom filters of other nodes to find the CID.

**Changes:**
* After receiving a PUT request, a node will update its bloom filter and publish it via gossipsub
* Counting bloom filters are used because they have a remove operation (useful for cache eviction)
* If a node receives a gossipsub message containing a bloom filter from another node, it will store the bloom filter in a map <del>(unless the sender is blacklisted)</del>

**Future work:**
* Bloom filters should be persisted to disk
* The map of bloom filters that each node stores should be kept up to date to avoid stale nodes

 The unit test `test_send_cache_summary` was coauthored together with @kckeiks.