### PR TITLE
feat: advertise file size

### DIFF
--- a/crates/ursa-gateway/Cargo.toml
+++ b/crates/ursa-gateway/Cargo.toml
@@ -11,6 +11,8 @@ description = "Ursa's proxy gateway"
 anyhow.workspace = true
 axum.workspace = true
 axum-server.workspace = true
+bincode.workspace = true
+base64.workspace = true
 tower = { workspace = true, features = ["full"] }
 tower-http = { workspace = true, features = ["full"] }
 cid.workspace = true

--- a/crates/ursa-gateway/src/resolver/mod.rs
+++ b/crates/ursa-gateway/src/resolver/mod.rs
@@ -12,7 +12,6 @@ use tracing::{debug, error, info, warn};
 use crate::resolver::model::Metadata;
 use crate::{resolver::model::ProviderResult, util::error::Error};
 
-// Base64 encoded. See ursa-index-provider::Metadata.
 const FLEEK_NETWORK_FILTER: &[u8] = b"FleekNetwork";
 
 type Client = hyper::client::Client<HttpsConnector<HttpConnector>, Body>;

--- a/crates/ursa-gateway/src/resolver/mod.rs
+++ b/crates/ursa-gateway/src/resolver/mod.rs
@@ -7,12 +7,13 @@ use hyper_tls::HttpsConnector;
 use libp2p::multiaddr::Protocol;
 use model::IndexerResponse;
 use serde_json::from_slice;
-use tracing::{debug, error};
+use tracing::{debug, error, info, warn};
 
+use crate::resolver::model::Metadata;
 use crate::{resolver::model::ProviderResult, util::error::Error};
 
 // Base64 encoded. See ursa-index-provider::Metadata.
-const ENCODED_METADATA: &str = "AAkAAAAAAAAAAAAAAAAAAAwAAAAAAAAARmxlZWtOZXR3b3Jr";
+const FLEEK_NETWORK_FILTER: &[u8] = b"FleekNetwork";
 
 type Client = hyper::client::Client<HttpsConnector<HttpConnector>, Body>;
 
@@ -75,20 +76,44 @@ impl Resolver {
 
         debug!("Received indexer response for {cid}: {indexer_response:?}");
 
-        let providers: Vec<&ProviderResult> = indexer_response
+        let providers: Vec<(&ProviderResult, Metadata)> = indexer_response
             .multihash_results
             .first()
             .context("Indexer result did not contain a multi-hash result")?
             .provider_results
             .iter()
-            .filter(|provider| provider.metadata == ENCODED_METADATA)
+            .filter_map(|provider| {
+                let metadata_bytes = match base64::decode(&provider.metadata) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        error!("Failed to decode metadata {e:?}");
+                        return None;
+                    }
+                };
+                let metadata = match bincode::deserialize::<Metadata>(&metadata_bytes) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        error!("Failed to deserialize metadata {e:?}");
+                        return None;
+                    }
+                };
+                if metadata.data == FLEEK_NETWORK_FILTER {
+                    return Some((provider, metadata));
+                }
+                warn!("Invalid data in metadata {:?}", metadata.data);
+                None
+            })
             .collect();
 
         // TODO:
         // cherry-pick closest node
-        let provider_addresses: Vec<String> = providers
+        let (provider, metadata) = providers
             .first() // FIXME: temporary
-            .context("Multi-hash result did not contain a provider")?
+            .context("Multi-hash result did not contain a provider")?;
+
+        info!("File size received {}", metadata.size);
+
+        let provider_addresses: Vec<String> = provider
             .provider
             .addrs
             .iter()

--- a/crates/ursa-gateway/src/resolver/model.rs
+++ b/crates/ursa-gateway/src/resolver/model.rs
@@ -32,3 +32,10 @@ pub struct AddrInfo {
     #[serde(rename = "Addrs")]
     pub addrs: Vec<Multiaddr>,
 }
+
+#[derive(Deserialize)]
+pub struct Metadata {
+    _protocol_id: u128,
+    pub size: u64,
+    pub data: Vec<u8>,
+}

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -22,6 +22,8 @@ struct Metadata {
     // Data is specific to the identified protocol, and provides data, or a
     // link to data, necessary for retrieval.
     Data: Vec<u8>,
+    // Size of the content.
+    Size: u64,
 }
 
 #[allow(non_snake_case)]
@@ -47,11 +49,18 @@ pub struct Advertisement {
     pub IsRm: bool,
 }
 impl Advertisement {
-    pub fn new(context_id: Vec<u8>, provider: PeerId, addresses: Vec<String>, is_rm: bool) -> Self {
+    pub fn new(
+        context_id: Vec<u8>,
+        provider: PeerId,
+        addresses: Vec<String>,
+        is_rm: bool,
+        content_size: u64,
+    ) -> Self {
         // prtocolid for bitswap
         let raw_metadata = Metadata {
             ProtocolID: 0x0900,
             Data: b"FleekNetwork".to_vec(),
+            Size: content_size,
         };
         let metadata = bincode::serialize(&raw_metadata).unwrap();
 

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -19,11 +19,11 @@ const AD_SIGNATURE_DOMAIN: &str = "indexer";
 struct Metadata {
     // ProtocolID defines the protocol used for data retrieval.
     ProtocolID: u128,
+    // Size of the content.
+    Size: u64,
     // Data is specific to the identified protocol, and provides data, or a
     // link to data, necessary for retrieval.
     Data: Vec<u8>,
-    // Size of the content.
-    Size: u64,
 }
 
 #[allow(non_snake_case)]

--- a/crates/ursa-index-provider/src/tests/engine_tests.rs
+++ b/crates/ursa-index-provider/src/tests/engine_tests.rs
@@ -10,7 +10,9 @@ mod tests {
     use tokio::{sync::oneshot, task};
     use tracing::{error, info};
 
-    use crate::{engine::ProviderCommand, signed_head::SignedHead, tests::provider_engine_init};
+    use crate::{
+        engine::ProviderCommand, signed_head::SignedHead, tests::provider_engine_init, Car,
+    };
 
     #[tokio::test]
     async fn test_events() -> Result<(), Box<dyn std::error::Error>> {
@@ -20,13 +22,16 @@ mod tests {
 
         let file = File::open("../../test_files/test.car".to_string()).await?;
         let reader = BufReader::new(file);
-        let cids = load_car(provider_engine.store().blockstore(), reader).await?;
+        let car = Car::from_file("../../test_files/test.car").await?;
+        let size = car.size;
+        let cids = load_car(provider_engine.store().blockstore(), car).await?;
 
         info!("The inserted cids are: {cids:?}");
 
         let (sender, receiver) = oneshot::channel();
         let message = ProviderCommand::Put {
             context_id: cids[0].to_bytes(),
+            size,
             sender,
         };
 

--- a/crates/ursa-index-provider/src/tests/engine_tests.rs
+++ b/crates/ursa-index-provider/src/tests/engine_tests.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use std::os::unix::fs::MetadataExt;
     use std::{thread, time::Duration};
 
     use anyhow::Error;
@@ -20,7 +19,7 @@ mod tests {
         let provider_interface = provider_engine.provider();
 
         let file = File::open("../../test_files/test.car".to_string()).await?;
-        let size = file.metadata().await?.size();
+        let size = file.metadata().await?.len();
         let reader = BufReader::new(file);
         let cids = load_car(provider_engine.store().blockstore(), reader).await?;
 

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -213,6 +213,7 @@ where
     }
 
     async fn put_car<R: AsyncRead + Send + Unpin>(&self, car: Car<R>) -> Result<Vec<Cid>> {
+        let size = car.size;
         let cids = load_car(self.store.blockstore(), car).await?;
         let root_cid = cids[0];
 
@@ -234,6 +235,7 @@ where
         let (sender, receiver) = oneshot::channel();
         let request = ProviderCommand::Put {
             context_id: root_cid.to_bytes(),
+            size,
             sender,
         };
         if let Err(e) = self.provider_send.send(request) {
@@ -281,7 +283,7 @@ where
 }
 
 pub struct Car<R> {
-    size: u64,
+    pub size: u64,
     reader: R,
 }
 

--- a/crates/ursa-rpc-service/src/http/routes/network.rs
+++ b/crates/ursa-rpc-service/src/http/routes/network.rs
@@ -1,6 +1,6 @@
 pub const BASE_PATH: &str = "./car_files";
 
-use crate::api::{NetworkInterface, NodeNetworkInterface};
+use crate::api::{Car, NetworkInterface, NodeNetworkInterface};
 use axum::{
     extract::{DefaultBodyLimit, Multipart, Path},
     http::header::{CONTENT_DISPOSITION, CONTENT_TYPE},
@@ -67,7 +67,10 @@ where
                 let vec_data = data.to_vec();
                 let reader = Cursor::new(&vec_data);
 
-                match interface.put_car(reader).await {
+                match interface
+                    .put_car(Car::new(vec_data.len() as u64, reader))
+                    .await
+                {
                     Err(err) => {
                         error!("{:?}", err);
                         Err(NetworkError::InternalError(err.to_string()))


### PR DESCRIPTION
Part of #210 

The gateway needs to stream large files directly from cache node without using its internal caching. The gateway needs to know the file size to make this decision. This proposal piggybacks on metadata. 

Input:
> -rw-r--r--   1 acadia  staff   27044 Dec 18 16:50 basic.car

Command:
> curl https://0.0.0.0:80/bafybeifyjj2bjhtxmp235vlfeeiy7sz6rzyx3lervfk3ap2nyn4rggqgei 

Output:
```
2023-01-10T16:28:22.387896Z  INFO ursa_gateway::worker: Dispatch FetchAnnounce command with cid: "bafybeifyjj2bjhtxmp235vlfeeiy7sz6rzyx3lervfk3ap2nyn4rggqgei"
2023-01-10T16:28:22.390121Z  INFO ursa_gateway::resolver: File size received 27044
```