### PR TITLE
chore(telemetry): set tracing tree log level and simplify default

### DIFF
--- a/crates/ursa-telemetry/src/lib.rs
+++ b/crates/ursa-telemetry/src/lib.rs
@@ -11,7 +11,7 @@ pub struct TelemetryConfig {
     /// Service name.
     pub name: String,
     /// Service log level.
-    pub log_level: Option<String>,
+    pub log_level: String,
     /// Service json log output.
     pub pretty_log: bool,
     /// Tokio console support.
@@ -28,7 +28,7 @@ impl TelemetryConfig {
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            log_level: None,
+            log_level: "INFO".to_string(),
             pretty_log: false,
             tokio_console: false,
             tree_tracer: false,
@@ -38,7 +38,7 @@ impl TelemetryConfig {
     }
 
     pub fn with_log_level(mut self, log_level: &str) -> Self {
-        self.log_level = Some(log_level.to_owned());
+        self.log_level = log_level.to_string();
         self
     }
 
@@ -68,14 +68,12 @@ impl TelemetryConfig {
     }
 
     pub fn init(self) -> anyhow::Result<()> {
-        let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::new(self.log_level.unwrap_or_else(|| "INFO".to_string()))
-        });
-
         let mut tracing_layers = vec![];
 
         if self.pretty_log {
-            let log_subscriber = fmt::layer().pretty().with_filter(env_filter);
+            let log_subscriber = fmt::layer()
+                .pretty()
+                .with_filter(EnvFilter::new(&self.log_level));
             tracing_layers.push(log_subscriber.boxed());
         }
 

--- a/crates/ursa-telemetry/src/lib.rs
+++ b/crates/ursa-telemetry/src/lib.rs
@@ -71,7 +71,7 @@ impl TelemetryConfig {
     pub fn init(self) -> anyhow::Result<()> {
         let log_level = self
             .log_level
-            .unwrap_or(env::var("RUST_LOG").unwrap_or("INFO".to_string()));
+            .unwrap_or_else(|| env::var("RUST_LOG").unwrap_or_else(|_| "INFO".to_string()));
 
         let mut tracing_layers = vec![];
 

--- a/crates/ursa-telemetry/src/lib.rs
+++ b/crates/ursa-telemetry/src/lib.rs
@@ -87,6 +87,7 @@ impl TelemetryConfig {
             let hierarchical_layer = HierarchicalLayer::new(2)
                 .with_targets(true)
                 .with_bracketed_fields(true)
+                .with_filter(EnvFilter::new(&self.log_level))
                 .boxed();
             tracing_layers.push(hierarchical_layer.boxed());
         }

--- a/crates/ursa/src/main.rs
+++ b/crates/ursa/src/main.rs
@@ -29,7 +29,6 @@ async fn main() -> Result<()> {
     let log_level = env::var("RUST_LOG").unwrap_or_else(|_| "INFO".to_string());
 
     TelemetryConfig::new("ursa-cli")
-        .with_pretty_log()
         .with_tree_tracer()
         .with_log_level(opts.log.as_ref().unwrap_or(&log_level))
         .init()?;


### PR DESCRIPTION
## Why

Currently the code is overcomplicated to load the log level. The preference should be: cli flag, then env var, then the default. Also, the log level provided is not respected by tracing tree, and tracing logs are printed due it not having a filter applied.

## What

- refactor/simplify the log level used
- add filter to tracing tree
- only use tracing tree for ursa bin to avoid duplicate logs

## Demo

![image](https://user-images.githubusercontent.com/8976745/210297178-4164bf52-a249-454f-96ec-1f7b2dfe763a.png)