### PR TITLE
feat: Use graphsync to pull data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ cid = "0.8.6"
 clap = { version = "4.0.29", features = ["derive"] }
 console-subscriber = "0.1.8"
 ctrlc = "3.2.4"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
+db = { package = "forest_db", version = "0.2.0", git = "https://github.com/kckeiks/forest-rocksdb", branch = "chore/derive-debug-rocksdb", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", branch = "downgrade-cid" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ctrlc = "3.2.4"
 db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
-ipld_traversal = { git = "https://github.com/retrieval-markets-lab/rs-graphsync.git", rev = "0a53cf5" }
+ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", branch = "downgrade-cid" }
 fastmurmur3 = "0.1.2"
 fnv = "1.0.7"
 futures = "0.3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ cid = "0.8.6"
 clap = { version = "4.0.29", features = ["derive"] }
 console-subscriber = "0.1.8"
 ctrlc = "3.2.4"
-db = { package = "forest_db", version = "0.2.0", git = "https://github.com/kckeiks/forest-rocksdb", branch = "chore/derive-debug-rocksdb", features = ["rocksdb"] }
+db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", branch = "downgrade-cid" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ futures-util = "0.3.25"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_car = "0.6.0"
 fvm_ipld_encoding = "0.3.0"
-graphsync = { git = "https://github.com/retrieval-markets-lab/rs-graphsync.git", rev = "0a53cf5" }
+graphsync = { git = "https://github.com/kckeiks/rs-graphsync.git",  branch = "downgrade-cid" }
 hyper = { version = "0.14.23", features = ["full"] }
 hyper-tls = "0.5.0"
 imara-diff = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ futures-util = "0.3.25"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_car = "0.6.0"
 fvm_ipld_encoding = "0.3.0"
+graphsync = { git = "https://github.com/retrieval-markets-lab/rs-graphsync.git", rev = "0a53cf5" }
 hyper = { version = "0.14.23", features = ["full"] }
 hyper-tls = "0.5.0"
 imara-diff = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ ctrlc = "3.2.4"
 db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
+ipld_traversal = { git = "https://github.com/retrieval-markets-lab/rs-graphsync.git", rev = "0a53cf5" }
 fastmurmur3 = "0.1.2"
 fnv = "1.0.7"
 futures = "0.3.25"

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -23,6 +23,7 @@ futures-util.workspace = true
 fvm_ipld_blockstore.workspace = true
 fvm_ipld_car.workspace = true
 graphsync.workspace = true
+ipld_traversal.workspace = true
 jsonrpc-v2.workspace = true
 libipld.workspace = true
 libp2p-bitswap.workspace = true

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -22,6 +22,7 @@ futures.workspace = true
 futures-util.workspace = true
 fvm_ipld_blockstore.workspace = true
 fvm_ipld_car.workspace = true
+graphsync.workspace = true
 jsonrpc-v2.workspace = true
 libipld.workspace = true
 libp2p-bitswap.workspace = true

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -15,8 +15,9 @@
 
 use anyhow::Result;
 use cid::Cid;
+use db::Store;
+use fvm_ipld_blockstore::Blockstore;
 use graphsync::GraphSync;
-use ipld_traversal::blockstore::Blockstore as GSBlockstore;
 use libipld::store::StoreParams;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
@@ -48,6 +49,7 @@ use std::{collections::HashSet, iter};
 
 use tracing::{info, warn};
 use ursa_metrics::BITSWAP_REGISTRY;
+use ursa_store::GraphSyncStorage;
 
 use crate::gossipsub::build_gossipsub;
 use crate::{
@@ -64,10 +66,10 @@ fn ursa_agent() -> String {
 
 /// Composes protocols for the behaviour of the node in the network.
 #[derive(NetworkBehaviour)]
-pub struct Behaviour<P, G>
+pub struct Behaviour<P, S>
 where
     P: StoreParams,
-    G: GSBlockstore + Send + Clone + 'static,
+    S: Blockstore + Clone + Store + Send + Sync + 'static,
 {
     /// Alive checks.
     ping: Ping,
@@ -103,19 +105,19 @@ where
     pub(crate) request_response: RequestResponse<UrsaExchangeCodec>,
 
     /// Graphsync for efficiently exchanging data between blocks between peers.
-    pub(crate) graphsync: GraphSync<G>,
+    pub(crate) graphsync: GraphSync<GraphSyncStorage<S>>,
 }
 
-impl<P, G> Behaviour<P, G>
+impl<P, S> Behaviour<P, S>
 where
     P: StoreParams,
-    G: GSBlockstore + Send + Clone + 'static,
+    S: Blockstore + Clone + Store + Send + Sync + 'static,
 {
-    pub fn new<S: BitswapStore<Params = P>>(
+    pub fn new<B: BitswapStore<Params = P>>(
         keypair: &Keypair,
         config: &NetworkConfig,
-        bitswap_store: S,
-        graphsync_store: G,
+        bitswap_store: B,
+        graphsync_store: GraphSyncStorage<S>,
         relay_client: Option<libp2p::relay::v2::client::Client>,
         peers: &mut HashSet<PeerId>,
     ) -> Self {
@@ -203,7 +205,7 @@ where
             Kademlia::with_config(local_peer_id, store, kad_config.clone())
         };
 
-        // Setup the Graphsync behaviour.
+        // Set up the Graphsync behaviour.
         let graphsync = GraphSync::new(graphsync_store);
 
         // init bootstraps

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use cid::Cid;
-use graphsync::{GraphSync, Request};
+use graphsync::GraphSync;
 use ipld_traversal::blockstore::MemoryBlockstore;
 use libipld::store::StoreParams;
 use libp2p::swarm::behaviour::toggle::Toggle;
@@ -99,7 +99,7 @@ pub struct Behaviour<P: StoreParams> {
     pub(crate) request_response: RequestResponse<UrsaExchangeCodec>,
 
     /// Graphsync for efficiently exchanging data between blocks between peers.
-    graphsync: GraphSync<MemoryBlockstore>,
+    pub(crate) graphsync: GraphSync<MemoryBlockstore>,
 }
 
 impl<P: StoreParams> Behaviour<P> {
@@ -276,9 +276,5 @@ impl<P: StoreParams> Behaviour<P> {
         providers: Vec<PeerId>,
     ) -> Result<libp2p_bitswap::QueryId> {
         Ok(self.bitswap.sync(cid, providers, iter::once(cid)))
-    }
-
-    pub fn graphsync_request(&mut self, peer: PeerId, request: Request) {
-        self.graphsync.request(peer, request);
     }
 }

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -15,8 +15,8 @@
 
 use anyhow::Result;
 use cid::Cid;
-use fvm_ipld_blockstore::MemoryBlockstore;
 use graphsync::{GraphSync, Request};
+use ipld_traversal::blockstore::MemoryBlockstore;
 use libipld::store::StoreParams;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
@@ -45,6 +45,7 @@ use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 use std::{collections::HashSet, iter};
+
 use tracing::{info, warn};
 use ursa_metrics::BITSWAP_REGISTRY;
 
@@ -194,7 +195,7 @@ impl<P: StoreParams> Behaviour<P> {
         };
 
         // Setup the Graphsync behaviour.
-        let graphsync = GraphSync::new(MemoryBlockstore::new());
+        let graphsync = GraphSync::new(MemoryBlockstore::default());
 
         // init bootstraps
         for addr in config.bootstrap_nodes.iter() {

--- a/crates/ursa-network/src/codec/protocol.rs
+++ b/crates/ursa-network/src/codec/protocol.rs
@@ -51,6 +51,7 @@ pub struct CarResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResponseType {
     CarResponse(CarResponse),
+    CacheResponse,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -599,10 +599,12 @@ where
                                     )
                                     .is_err()
                                 {
-                                    error!("[BehaviourEvent::RequestMessage] failed to send response")
+                                    error!(
+                                        "[BehaviourEvent::RequestMessage] failed to send response"
+                                    )
                                 }
                             }
-                        },
+                        }
                         RequestType::StoreSummary(cache_summary) => {
                             self.peer_cached_content.insert(peer, cache_summary);
                         }

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -895,7 +895,7 @@ where
                     self.swarm
                         .behaviour_mut()
                         .graphsync
-                        .request(peer.clone(), req);
+                        .request(*peer, req);
                 }
             }
             #[cfg(test)]

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -623,11 +623,11 @@ where
                 peer_id,
                 received,
             } => {
-                info!("[GraphSyncEvent::Completed] {id} {peer_id} {received}");
+                info!("[GraphSyncEvent::Completed]: {id} {peer_id} {received}");
 
                 if !self.gs_ongoing_requests.contains_key(&id) {
                     error!(
-                        "[GraphSyncEvent::Completed] did not find corresponding pending request"
+                        "[GraphSyncEvent::Completed]: did not find corresponding pending request"
                     );
                     return Ok(());
                 }
@@ -635,12 +635,12 @@ where
                 let cid = self.gs_ongoing_requests.remove(&id).expect("Key to exist");
                 let sender = self.gs_response_channels.remove(&cid).unwrap();
                 if sender.send(Ok(())).is_err() {
-                    error!("[GraphSyncEvent] failed to send response")
+                    error!("[GraphSyncEvent]: failed to send response")
                 }
                 Ok(())
             }
             event => {
-                info!("Other: [{event:?}]");
+                info!("[GraphSyncEvent]: {event:?}");
                 Ok(())
             }
         }
@@ -685,10 +685,7 @@ where
                 }
                 BehaviourEvent::RelayClient(_) => Ok(()),
                 BehaviourEvent::Dcutr(_) => Ok(()),
-                BehaviourEvent::Graphsync(event) => {
-                    // SentRequest
-                    self.handle_graphsync(event)
-                }
+                BehaviourEvent::Graphsync(event) => self.handle_graphsync(event),
             },
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 if self.peers.insert(peer_id) {
@@ -860,7 +857,6 @@ where
                 }
             },
             NetworkCommand::GetGraphSync { cid, sender } => {
-                // Construct the request.
                 if self.peers.is_empty() {
                     error!("[GetGraphSync]: empty peers");
                     sender

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -631,9 +631,17 @@ where
                     );
                     return Ok(());
                 }
-
                 let cid = self.gs_ongoing_requests.remove(&id).expect("Key to exist");
-                let sender = self.gs_response_channels.remove(&cid).unwrap();
+                if !self.gs_response_channels.contains_key(&cid) {
+                    info!(
+                        "[GraphSyncEvent::Completed]: did not find sender... it's possible that sender has already been notified"
+                    );
+                    return Ok(());
+                }
+                let sender = self
+                    .gs_response_channels
+                    .remove(&cid)
+                    .expect("Key to exist");
                 if sender.send(Ok(())).is_err() {
                     error!("[GraphSyncEvent]: failed to send response")
                 }

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -572,37 +572,33 @@ where
                 } => {
                     match request.0 {
                         RequestType::CarRequest(_) => (),
-                        RequestType::CacheRequest(_) => {
-                            if let UrsaExchangeRequest(RequestType::CacheRequest(cid)) = request {
-                                info!("[BehaviourEvent::RequestMessage] cache request from {peer} for {cid}");
+                        RequestType::CacheRequest(cid) => {
+                            info!("[BehaviourEvent::RequestMessage] cache request from {peer} for {cid}");
 
-                                let selector = Selector::ExploreRecursive {
-                                    limit: RecursionLimit::None,
-                                    sequence: Box::new(Selector::ExploreAll {
-                                        next: Box::new(Selector::ExploreRecursiveEdge),
-                                    }),
-                                    current: None,
-                                };
+                            let selector = Selector::ExploreRecursive {
+                                limit: RecursionLimit::None,
+                                sequence: Box::new(Selector::ExploreAll {
+                                    next: Box::new(Selector::ExploreRecursiveEdge),
+                                }),
+                                current: None,
+                            };
 
-                                let req = Request::builder()
-                                    .root(cid.to_bytes())
-                                    .selector(selector)
-                                    .build()
-                                    .unwrap();
-                                let swarm = self.swarm.behaviour_mut();
-                                swarm.graphsync.request(peer, req);
-                                if swarm
-                                    .request_response
-                                    .send_response(
-                                        channel,
-                                        UrsaExchangeResponse(ResponseType::CacheResponse),
-                                    )
-                                    .is_err()
-                                {
-                                    error!(
-                                        "[BehaviourEvent::RequestMessage] failed to send response"
-                                    )
-                                }
+                            let req = Request::builder()
+                                .root(cid.to_bytes())
+                                .selector(selector)
+                                .build()
+                                .unwrap();
+                            let swarm = self.swarm.behaviour_mut();
+                            swarm.graphsync.request(peer, req);
+                            if swarm
+                                .request_response
+                                .send_response(
+                                    channel,
+                                    UrsaExchangeResponse(ResponseType::CacheResponse),
+                                )
+                                .is_err()
+                            {
+                                error!("[BehaviourEvent::RequestMessage] failed to send response")
                             }
                         }
                         RequestType::StoreSummary(cache_summary) => {

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -892,10 +892,7 @@ where
                     info!("[GetGraphSync]: enqueue pending response");
                     self.gs_response_channels.insert(*req.id(), sender);
 
-                    self.swarm
-                        .behaviour_mut()
-                        .graphsync
-                        .request(*peer, req);
+                    self.swarm.behaviour_mut().graphsync.request(*peer, req);
                 }
             }
             #[cfg(test)]

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -607,6 +607,20 @@ where
                         }
                         RequestType::StoreSummary(cache_summary) => {
                             self.peer_cached_content.insert(peer, cache_summary);
+                            if self
+                                .swarm
+                                .behaviour_mut()
+                                .request_response
+                                .send_response(
+                                    channel,
+                                    UrsaExchangeResponse(ResponseType::StoreSummaryRequest),
+                                )
+                                .is_err()
+                            {
+                                error!(
+                                        "[BehaviourEvent::RequestMessage] failed to send StoreSummaryRequest response"
+                                    )
+                            }
                         }
                     }
                     trace!("[BehaviourEvent::RequestMessage] {} ", peer);

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -73,11 +73,11 @@ pub const MESSAGE_PROTOCOL: &[u8] = b"/ursa/message/0.0.1";
 
 type BlockOneShotSender<T> = oneshot::Sender<Result<T, Error>>;
 type SwarmEventType<S> = SwarmEvent<
-<Behaviour<DefaultParams, GraphSyncStorage<S>> as NetworkBehaviour>::OutEvent,
+<Behaviour<DefaultParams, S> as NetworkBehaviour>::OutEvent,
 <
     <
         <
-            Behaviour<DefaultParams, GraphSyncStorage<S>> as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler
+            Behaviour<DefaultParams, S> as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler
         >::Handler as ConnectionHandler
     >::Error
 >;
@@ -194,12 +194,12 @@ pub enum NetworkCommand {
 
 pub struct UrsaService<S>
 where
-    S: Blockstore + Store + Clone + Send + Sync + 'static,
+    S: Blockstore + Clone + Debug + Store + Send + Sync + 'static,
 {
     /// Store.
     pub store: Arc<UrsaStore<S>>,
     /// The main libp2p swarm emitting events.
-    swarm: Swarm<Behaviour<DefaultParams, GraphSyncStorage<S>>>,
+    swarm: Swarm<Behaviour<DefaultParams, S>>,
     /// Handles outbound messages to peers.
     command_sender: Sender<NetworkCommand>,
     /// Handles inbound messages from peers.
@@ -232,7 +232,7 @@ where
 
 impl<S> UrsaService<S>
 where
-    S: Blockstore + Store + Clone + Debug + Send + Sync + 'static,
+    S: Blockstore + Clone + Debug + Store + Send + Sync + 'static,
 {
     /// Init a new [`UrsaService`] based on [`NetworkConfig`]
     ///

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -766,7 +766,7 @@ where
                 // replicate content
                 let swarm = self.swarm.behaviour_mut();
                 for peer in &self.peers {
-                    info!("Sending to peer {peer}");
+                    info!("[NetworkCommand::Put] - sending cache request to peer {peer} for {cid}");
                     swarm
                         .request_response
                         .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -594,7 +594,7 @@ where
 
                         let req = Request::builder()
                             .root(cid.to_bytes())
-                            .selector(selector.clone())
+                            .selector(selector)
                             .build()
                             .unwrap();
                         let swarm = self.swarm.behaviour_mut();

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -521,8 +521,8 @@ mod tests {
 
         // Wait for node 1 to send cache request to node 2.
         // Wait for node 2 to pull content from node 1.
-        for _ in 0..3 {
-            tokio::time::sleep(Duration::from_secs(2)).await;
+        for s in (3..6).rev() {
+            tokio::time::sleep(Duration::from_secs(s)).await;
 
             let store_1_block = graphsync_store_2.get(block.cid()).unwrap();
             info!("Block received {store_1_block:?}");

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -497,14 +497,15 @@ mod tests {
         // Wait for node 2 to finish bootstrapping.
         loop {
             if let SwarmEvent::Behaviour(BehaviourEvent::Kad(
-                KademliaEvent::OutboundQueryProgressed { result, .. },
+                KademliaEvent::OutboundQueryProgressed {
+                    result: QueryResult::Bootstrap(Ok(BootstrapOk { num_remaining, .. })),
+                    ..
+                },
             )) = node_2.swarm.select_next_some().await
             {
-                if let QueryResult::Bootstrap(Ok(BootstrapOk { num_remaining, .. })) = result {
-                    if num_remaining == 0 {
-                        info!("[KademliaEvent::Bootstrap]: Node 2 is done bootstrapping");
-                        break;
-                    }
+                if num_remaining == 0 {
+                    info!("[KademliaEvent::Bootstrap]: Node 2 is done bootstrapping");
+                    break;
                 }
             }
         }

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -497,14 +497,10 @@ mod tests {
         // Wait for node 2 to finish bootstrapping.
         loop {
             if let SwarmEvent::Behaviour(BehaviourEvent::Kad(
-                KademliaEvent::OutboundQueryProgressed { id, result, .. },
+                KademliaEvent::OutboundQueryProgressed { result, .. },
             )) = node_2.swarm.select_next_some().await
             {
-                if let QueryResult::Bootstrap(Ok(BootstrapOk {
-                    peer,
-                    num_remaining,
-                })) = result
-                {
+                if let QueryResult::Bootstrap(Ok(BootstrapOk { num_remaining, .. })) = result {
                     if num_remaining == 0 {
                         info!("[KademliaEvent::Bootstrap]: Node 2 is done bootstrapping");
                         break;

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -541,7 +541,7 @@ mod tests {
         let graphsync_store_2 = GraphSyncStorage(store_2.clone());
 
         let block = get_block(&b"hello world"[..]);
-        info!("inserting block into bitswap store for node 1");
+        info!("inserting block into Graphsync store for node 1");
         graphsync_store_1.insert(&block).unwrap();
 
         assert!(graphsync_store_1.has(block.cid()).unwrap());
@@ -576,14 +576,14 @@ mod tests {
 
         let res = receiver
             .await
-            .expect("Unable to receive from bitswap channel");
+            .expect("Unable to receive from Graphsync channel");
 
         match res {
             Ok(_) => {
                 let store_1_block = graphsync_store_2.get(block.cid()).unwrap();
 
                 info!(
-                    "inserting block into bitswap store for node 1, {:?}",
+                    "inserting block into Graphsync store for node 1, {:?}",
                     store_1_block
                 );
                 assert_eq!(store_1_block, Some(block.data().to_vec()));
@@ -649,7 +649,7 @@ mod tests {
 
         let res = receiver
             .await
-            .expect("Unable to receive from bitswap channel");
+            .expect("Unable to receive from Graphsync channel");
 
         match res {
             Ok(_) => {

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -521,7 +521,7 @@ mod tests {
 
         // Wait for node 1 to send cache request to node 2.
         // Wait for node 2 to pull content from node 1.
-        for s in (3..6).rev() {
+        for s in (3..5).rev() {
             tokio::time::sleep(Duration::from_secs(s)).await;
 
             let store_1_block = graphsync_store_2.get(block.cid()).unwrap();

--- a/crates/ursa-store/Cargo.toml
+++ b/crates/ursa-store/Cargo.toml
@@ -19,6 +19,7 @@ futures.workspace = true
 fvm_ipld_blockstore.workspace = true
 fvm_ipld_car.workspace = true
 fvm_ipld_encoding.workspace = true
+ipld_traversal.workspace = true
 libipld.workspace = true
 libp2p-bitswap.workspace = true
 serde.workspace = true

--- a/crates/ursa-store/src/store.rs
+++ b/crates/ursa-store/src/store.rs
@@ -12,6 +12,7 @@ use libipld::{store::DefaultParams, Block, Result};
 use libp2p_bitswap::BitswapStore;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct UrsaStore<S> {
     pub db: Arc<S>,
 }
@@ -170,6 +171,7 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct GraphSyncStorage<P>(pub Arc<UrsaStore<P>>)
 where
     P: Blockstore + Store + Send + Sync + 'static;

--- a/crates/ursa-store/src/store.rs
+++ b/crates/ursa-store/src/store.rs
@@ -176,6 +176,21 @@ pub struct GraphSyncStorage<P>(pub Arc<UrsaStore<P>>)
 where
     P: Blockstore + Store + Send + Sync + 'static;
 
+impl<S> GraphSyncStorage<S>
+where
+    S: Blockstore + Store + Send + Sync + 'static,
+{
+    pub fn insert(&mut self, block: &Block<DefaultParams>) -> Result<()> {
+        self.0.db.put_keyed(block.cid(), block.data()).unwrap();
+
+        Ok(())
+    }
+
+    pub fn get(&mut self, cid: &Cid) -> Result<Option<Vec<u8>>> {
+        Ok(self.0.db.get(cid).unwrap())
+    }
+}
+
 impl<S> GSBlockstore for GraphSyncStorage<S>
 where
     S: Blockstore + Store + Send + Sync + 'static,

--- a/crates/ursa-store/src/store.rs
+++ b/crates/ursa-store/src/store.rs
@@ -7,6 +7,7 @@ use db::Store;
 use fnv::FnvHashSet;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec, DAG_CBOR};
+use ipld_traversal::blockstore::Blockstore as GSBlockstore;
 use libipld::{store::DefaultParams, Block, Result};
 use libp2p_bitswap::BitswapStore;
 use std::sync::Arc;
@@ -166,6 +167,30 @@ where
             }
         }
         Ok(res)
+    }
+}
+
+pub struct GraphSyncStorage<P>(pub Arc<UrsaStore<P>>)
+where
+    P: Blockstore + Store + Send + Sync + 'static;
+
+impl<S> GSBlockstore for GraphSyncStorage<S>
+where
+    S: Blockstore + Store + Send + Sync + 'static,
+{
+    fn get(&self, k: &cid::Cid) -> Result<Option<Vec<u8>>> {
+        self.0.blockstore().get(k)
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
+        self.0.blockstore().put_keyed(k, block)
+    }
+
+    fn delete_block(&self, k: &Cid) -> Result<()> {
+        self.0
+            .blockstore()
+            .delete(k.to_bytes())
+            .map_err(|e| e.into())
     }
 }
 


### PR DESCRIPTION
This adds `rs-graphsync` to ursa service. This still needs some work and testing. I'm working on other tasks that will probably come in separate prs. In this pr we add minimal support to perform a graphsync pull request from peers.

 I ended up having to fork `rs-graphsync` and downgrade `libipld` because of dependency conflicts. Opened #239 to address it in the future.

- [x] ~Handle pending queries when pulling from multiple peers (maybe naive version then robust version in a follow up PR)~ Handle `CacheRequest` and pull content using graphsync #214.
- [x] Integrate `graphsync::Blockstore` trait with UrsaStore ~(follow up PR)~
- [x] Add unit test