### PR TITLE
refactor: 💡 docker run bind mount ursa config default path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker-build:
 	docker build -t ursa -f ./Dockerfile .
 
 docker-run:
-	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 -p 8070:8070 --name ursa-cli -it ursa
+	docker run -p 4069:4069 -p 4070:4070 -p 6009:6009 -p 8070:8070 -v $HOME/.ursa/:/root/.ursa/:rw --name ursa-cli -it ursa
 
 compose-build:
 	docker-compose -f infra/ursa/docker-compose.yml build


### PR DESCRIPTION
The following declares a bind mount from host path to container, which is used to persist the ursa config directory from default ursa home directory.