### PR TITLE
feat: auto-upgraded configs using defaults + log the differences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ fvm_ipld_car = "0.6.0"
 fvm_ipld_encoding = "0.3.0"
 hyper = { version = "0.14.23", features = ["full"] }
 hyper-tls = "0.5.0"
+imara-diff = "0.1.5"
 jsonrpc-v2 = "0.11.0"
 lazy_static = "1.4"
 libipld = "0.14.0"

--- a/crates/ursa-index-provider/src/config.rs
+++ b/crates/ursa-index-provider/src/config.rs
@@ -1,24 +1,34 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-const DEFAULT_DB_PATH_STR: &str = "~/.ursa/data/index_provider_db";
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderConfig {
-    /// a domain where provider is listening dns/test-node.provider.ursa.earth
+    /// a domain where the node is listening, eg. `dns/test-node.ursa.earth`
+    #[serde(default)]
     pub domain: String,
-    /// indexer url to point to e.g. https://dev.cid.contact
+    /// indexer url to point to, eg. https://dev.cid.contact
+    #[serde(default = "ProviderConfig::default_indexer_url")]
     pub indexer_url: String,
     /// database_path for index provider db
+    #[serde(default = "ProviderConfig::default_database_path")]
     pub database_path: PathBuf,
+}
+
+impl ProviderConfig {
+    fn default_database_path() -> PathBuf {
+        "~/.ursa/data/index_provider_db".into()
+    }
+    fn default_indexer_url() -> String {
+        "https://dev.cid.contact".to_string()
+    }
 }
 
 impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
             domain: "".to_string(),
-            indexer_url: "https://dev.cid.contact".to_string(),
-            database_path: DEFAULT_DB_PATH_STR.into(),
+            indexer_url: Self::default_indexer_url(),
+            database_path: Self::default_database_path(),
         }
     }
 }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -2,65 +2,102 @@ use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub const DEFAULT_TRACKER_URL: &str = "https://tracker.ursa.earth/register";
-pub const DEFAULT_BOOTSTRAP: [&str; 2] = [
-    "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p",
-    "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM",
-];
-pub const DEFAULT_DB_PATH_STR: &str = "~/.ursa/data/ursa_db";
-pub const DEFAULT_KEYSTORE_PATH_STR: &str = "~/.ursa/keystore";
-
 /// Ursa Configuration
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct NetworkConfig {
     /// Optional mdns local discovery.
+    #[serde(default = "NetworkConfig::default_mdns")]
     pub mdns: bool,
     /// Optional Provide a relay server for other peers to listen on.
+    #[serde(default = "NetworkConfig::default_relay_server")]
     pub relay_server: bool,
     /// Optional autonat. This is used to determine if we are behind a NAT and need to use a relay.
+    #[serde(default = "NetworkConfig::default_autonat")]
     pub autonat: bool,
     /// Optional Enable listening on a relay server if not publicly available. Requires autonat.
     /// Connections will attempt to upgrade using dcutr.
+    #[serde(default = "NetworkConfig::default_relay_client")]
     pub relay_client: bool,
     /// set true if it is a bootstrap node. default = false
+    #[serde(default = "NetworkConfig::default_bootstrapper")]
     pub bootstrapper: bool,
     /// Swarm listening Address.
+    #[serde(default = "NetworkConfig::default_swarm_addrs")]
     pub swarm_addrs: Vec<Multiaddr>,
     /// Bootstrap nodes.
+    #[serde(default = "NetworkConfig::default_bootstrap_nodes")]
     pub bootstrap_nodes: Vec<Multiaddr>,
     /// Database path.
+    #[serde(default = "NetworkConfig::default_database_path")]
     pub database_path: PathBuf,
     /// user identity name
+    #[serde(default = "NetworkConfig::default_identity")]
     pub identity: String,
     /// Keystore path. Defaults to ~/.ursa/keystore
+    #[serde(default = "NetworkConfig::default_keystore_path")]
     pub keystore_path: PathBuf,
     /// Temporary HTTP tracker url. This is used for pre-consensus node registrations.
     /// Defaults to devnet tracker.
+    #[serde(default = "NetworkConfig::default_tracker")]
     pub tracker: String,
+}
+
+impl NetworkConfig {
+    fn default_mdns() -> bool {
+        false
+    }
+    fn default_autonat() -> bool {
+        true
+    }
+    fn default_relay_client() -> bool {
+        true
+    }
+    fn default_relay_server() -> bool {
+        true
+    }
+    fn default_bootstrapper() -> bool {
+        false
+    }
+    fn default_tracker() -> String {
+        "https://tracker.ursa.earth/register".to_string()
+    }
+    fn default_bootstrap_nodes() -> Vec<Multiaddr> {
+        vec![
+            "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p".parse().unwrap(),
+            "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM".parse().unwrap(),
+        ]
+    }
+    fn default_swarm_addrs() -> Vec<Multiaddr> {
+        vec![
+            "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
+            "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap()
+        ]
+    }
+    fn default_database_path() -> PathBuf {
+        "~/.ursa/data/ursa_db".into()
+    }
+    fn default_keystore_path() -> PathBuf {
+        "~/.ursa/keystore".into()
+    }
+    fn default_identity() -> String {
+        "default".to_string()
+    }
 }
 
 impl Default for NetworkConfig {
     fn default() -> Self {
-        let bootstrap_nodes = DEFAULT_BOOTSTRAP
-            .iter()
-            .map(|node| node.parse().unwrap())
-            .collect();
-
         Self {
-            mdns: false,
-            autonat: true,
-            relay_client: true,
-            relay_server: true,
-            bootstrap_nodes,
-            bootstrapper: false,
-            swarm_addrs: vec![
-                "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
-                "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap(),
-            ],
-            database_path: DEFAULT_DB_PATH_STR.into(),
-            identity: "default".to_string(),
-            tracker: DEFAULT_TRACKER_URL.into(),
-            keystore_path: DEFAULT_KEYSTORE_PATH_STR.into(),
+            mdns: Self::default_mdns(),
+            autonat: Self::default_autonat(),
+            relay_client: Self::default_relay_client(),
+            relay_server: Self::default_relay_server(),
+            bootstrapper: Self::default_bootstrapper(),
+            bootstrap_nodes: Self::default_bootstrap_nodes(),
+            swarm_addrs: Self::default_swarm_addrs(),
+            database_path: Self::default_database_path(),
+            identity: Self::default_identity(),
+            tracker: Self::default_tracker(),
+            keystore_path: Self::default_keystore_path(),
         }
     }
 }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -70,7 +70,7 @@ impl NetworkConfig {
     fn default_swarm_addrs() -> Vec<Multiaddr> {
         vec![
             "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
-            "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap()
+            "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap(),
         ]
     }
     fn default_database_path() -> PathBuf {

--- a/crates/ursa-rpc-service/src/config.rs
+++ b/crates/ursa-rpc-service/src/config.rs
@@ -2,20 +2,26 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ServerConfig {
+    #[serde(default = "ServerConfig::default_port")]
     pub port: u16,
+    #[serde(default = "ServerConfig::default_addr")]
     pub addr: String,
 }
 
 impl ServerConfig {
-    pub fn new(port: u16, addr: String) -> Self {
-        Self { port, addr }
+    fn default_port() -> u16 {
+        4069
+    }
+    fn default_addr() -> String {
+        "0.0.0.0".to_string()
     }
 }
+
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
-            port: 4069,
-            addr: "0.0.0.0".to_string(),
+            port: Self::default_port(),
+            addr: Self::default_addr(),
         }
     }
 }

--- a/crates/ursa/Cargo.toml
+++ b/crates/ursa/Cargo.toml
@@ -30,3 +30,4 @@ ursa-rpc-service = { path = "../ursa-rpc-service" }
 ursa-store = { path = "../ursa-store" }
 ursa-telemetry = { path = "../ursa-telemetry" }
 ursa-tracker = { path = "../ursa-tracker" }
+imara-diff.workspace = true

--- a/crates/ursa/src/config.rs
+++ b/crates/ursa/src/config.rs
@@ -1,58 +1,73 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
+use imara_diff::{intern::InternedInput, sink::Counter, Algorithm, UnifiedDiffBuilder};
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use std::{
     fs::{create_dir_all, File},
     io::{Read, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-use toml::from_str;
-use tracing::info;
+use tracing::{info, warn};
 use ursa_index_provider::config::ProviderConfig;
 use ursa_network::NetworkConfig;
 use ursa_rpc_service::config::ServerConfig;
 
 pub const DEFAULT_CONFIG_PATH_STR: &str = ".ursa/config.toml";
 
-/// Load an UrsaConfig from a path. If the path does not exist, a default config will be created and returned.
-pub fn load_config(path: &PathBuf) -> Result<UrsaConfig> {
-    info!("Loading config from: {:?}", path);
-    if path.exists() {
-        let toml = read_file_to_string(path).context(format!(
-            "Failed to read config file {}",
-            path.to_string_lossy()
-        ))?;
-        from_str(&toml).map_err(|e| anyhow!("Failed to parse config toml: {}", e))
-    } else {
-        // Config missing, create and return default config at path
-        let ursa_config = UrsaConfig::default();
-        let toml = toml::to_string(&ursa_config).unwrap();
-        create_dir_all(path.parent().unwrap()).context(format!(
-            "Failed to create default config directory: {}",
-            path.to_string_lossy()
-        ))?;
-        let mut file = File::create(path).context(format!(
-            "Failed to create default config file: {}",
-            path.to_string_lossy()
-        ))?;
-        file.write_all(toml.as_bytes()).context(format!(
-            "Failed to write to default config file: {}",
-            path.to_string_lossy()
-        ))?;
-        Ok(ursa_config)
-    }
-}
-
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct UrsaConfig {
+    #[serde(default)]
     pub network_config: NetworkConfig,
+    #[serde(default)]
     pub provider_config: ProviderConfig,
+    #[serde(default)]
     pub server_config: ServerConfig,
 }
 
-/// Read file as a `String`.
-pub fn read_file_to_string(path: &Path) -> Result<String> {
-    let mut file = File::open(path)?;
-    let mut string = String::new();
-    file.read_to_string(&mut string)?;
-    Ok(string)
+impl UrsaConfig {
+    /// Load an UrsaConfig from a given path, or create a default one if not found.
+    pub fn load_or_default(path: &PathBuf) -> Result<UrsaConfig> {
+        info!("Loading config from: {:?}", path);
+        if path.exists() {
+            // read file
+            let mut file = File::open(path)?;
+            let mut raw = String::new();
+            file.read_to_string(&mut raw)?;
+
+            let config: UrsaConfig = toml::from_str(&raw).context("Failed to parse config file")?;
+
+            // check if we modified the config at all
+            let config_str = toml::to_string(&config)?;
+            let input = InternedInput::new(raw.as_str(), config_str.as_str());
+            let diff = imara_diff::diff(
+                Algorithm::Histogram,
+                &input,
+                Counter::new(UnifiedDiffBuilder::new(&input)),
+            );
+            if diff.total() > 0 {
+                warn!(
+                    "Config `{path:?}` was automatically modified and saved to disk:\n\n{}",
+                    diff.wrapped
+                );
+                write(config_str, path)?;
+            }
+
+            Ok(config)
+        } else {
+            warn!("Config `{path:?}` not found, writing default config");
+            // Config missing, create and return default config at path
+            let config = UrsaConfig::default();
+            write(toml::to_string(&config)?, path)?;
+
+            Ok(config)
+        }
+    }
+}
+
+pub fn write<S: Display, P: Into<PathBuf>>(str: S, path: P) -> Result<()> {
+    let path = path.into();
+    create_dir_all(path.parent().unwrap())?;
+    let mut file = File::create(path)?;
+    file.write_all(str.to_string().as_bytes())?;
+    Ok(())
 }

--- a/crates/ursa/src/ursa/mod.rs
+++ b/crates/ursa/src/ursa/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::{load_config, UrsaConfig, DEFAULT_CONFIG_PATH_STR};
+use crate::config::{UrsaConfig, DEFAULT_CONFIG_PATH_STR};
 use anyhow::Result;
 use dirs::home_dir;
 use resolve_path::PathResolveExt;
@@ -45,7 +45,7 @@ pub enum Subcommand {
 #[derive(StructOpt, Debug)]
 pub struct CliOpts {
     #[structopt(short, long, help = "A toml file containing relevant configurations")]
-    pub config: Option<String>,
+    pub config: Option<PathBuf>,
     #[structopt(short, long, help = "Allow rpc to be active or not (default = true)")]
     pub rpc: bool,
     #[structopt(short = "p", long, help = "Port used for JSON-RPC communication")]
@@ -60,11 +60,11 @@ pub struct CliOpts {
 
 impl CliOpts {
     pub fn to_config(&self) -> Result<UrsaConfig> {
-        let mut config = load_config(
+        let mut config = UrsaConfig::load_or_default(
             &self
                 .config
                 .as_ref()
-                .map(|p| PathBuf::from(p).resolve().to_path_buf())
+                .map(|p| p.resolve().to_path_buf())
                 .unwrap_or_else(|| home_dir().unwrap_or_default().join(DEFAULT_CONFIG_PATH_STR)),
         )?;
 


### PR DESCRIPTION
## Why

ursa bin errors if config is invalid

## What

- Provide deserialization defaults to automatically populate missing values
- Calculate unified diff on the toml we end up with after parsing
- If changes were made, log the diff and save the new config to file

## Demo

Example showing loading a config with some fields removed and old invalid fields added

![image](https://user-images.githubusercontent.com/8976745/210628089-0f52d836-4f43-4109-991a-ea27bfa69487.png)

We can also easily rename a field by modifying an attribute on a field like so:

```rust 
#[derive(Deserialize)]
struct ExampleConfig {
   #[serde(
       default = "default_example_fn",
       rename(deserialize = "old_name", deserialize = "new_name")
   )]
   new_name: String,
}
```

Which would result in the old name getting overwritten while preserving the value due to serializing into the new name

## Other notes

- This is currently implemented to be non-blocking and just a warning to avoid issues with automated/headless setups etc. Should it instead have a confirmation step (that's optionally skippable with a flag) that allows user to choose to accept or deny the changes?

- This will remove comments from the config file

---

closes #135 
