### PR TITLE
fix: rpc put

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -303,6 +303,10 @@ where
         })
     }
 
+    pub fn close_command_receiver(&mut self) {
+        self.command_receiver.close();
+    }
+
     pub fn command_sender(&self) -> Sender<NetworkCommand> {
         self.command_sender.clone()
     }

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -216,13 +216,17 @@ where
 
         info!("The inserted cids are: {cids:?}");
 
-        let (sender, _) = oneshot::channel();
+        let (sender, receiver) = oneshot::channel();
         let request = NetworkCommand::Put {
             cid: root_cid,
             sender,
         };
         if let Err(e) = self.network_send.send(request) {
             error!("There was an error while sending NetworkCommand::Put: {e}");
+        } else {
+            if let Err(e) = receiver.await {
+                return Err(anyhow!(format!("The PUT failed, please check server logs {e:?}")));
+            }
         }
 
         let (sender, receiver) = oneshot::channel();

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -223,10 +223,10 @@ where
         };
         if let Err(e) = self.network_send.send(request) {
             error!("There was an error while sending NetworkCommand::Put: {e}");
-        } else {
-            if let Err(e) = receiver.await {
-                return Err(anyhow!(format!("The PUT failed, please check server logs {e:?}")));
-            }
+        } else if let Err(e) = receiver.await {
+            return Err(anyhow!(format!(
+                "The PUT failed, please check server logs {e:?}"
+            )));
         }
 
         let (sender, receiver) = oneshot::channel();

--- a/crates/ursa-rpc-service/src/tests/api_test.rs
+++ b/crates/ursa-rpc-service/src/tests/api_test.rs
@@ -11,7 +11,7 @@ mod tests {
     #[tokio::test]
     async fn test_put_and_get() -> anyhow::Result<()> {
         setup_logger();
-        let (ursa_service, mut provider_engine, store) = init()?;
+        let (mut ursa_service, mut provider_engine, store) = init()?;
 
         let interface = Arc::new(NodeNetworkInterface {
             store: Arc::clone(&store),
@@ -22,6 +22,7 @@ mod tests {
         // the test case does not start the provider engine, so the best way
         // for put_file to not call provider engine is to close the channel
         provider_engine.command_receiver().close();
+        ursa_service.close_command_receiver();
 
         let put_file = interface
             .put_file("../../test_files/test.car".to_string())


### PR DESCRIPTION
Omitting the receiver for `NetworkCommand::Put` was causing rpc put requests to fail.
Thanks to @scott-dn for pointing this out.