### PR TITLE
feat: send cache summary using request response

### DIFF
--- a/crates/ursa-network/src/codec/protocol.rs
+++ b/crates/ursa-network/src/codec/protocol.rs
@@ -1,3 +1,4 @@
+use crate::utils::bloom_filter::CountingBloomFilter;
 use async_trait::async_trait;
 use cid::Cid;
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -36,6 +37,7 @@ pub enum RequestType {
     // change this to the final cid version
     CarRequest(String),
     CacheRequest(Cid),
+    StoreSummary(CountingBloomFilter),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,6 +53,7 @@ pub struct CarResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResponseType {
     CarResponse(CarResponse),
+    StoreSummaryRequest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ursa-network/src/utils/bloom_filter.rs
+++ b/crates/ursa-network/src/utils/bloom_filter.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CountingBloomFilter {
@@ -73,6 +74,14 @@ impl CountingBloomFilter {
         (((m as f64) / (n as f64)) * 2.0f64.ln()).ceil() as usize
     }
 }
+
+impl PartialEq for CountingBloomFilter {
+    fn eq(&self, other: &Self) -> bool {
+        self.num_hashes == other.num_hashes && self.buckets.eq(&other.buckets)
+    }
+}
+
+impl Eq for CountingBloomFilter {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Why
At the moment, after receiving a PUT request, nodes will send their bloom filters to the network using gossipsub.
This will significantly increase network traffic. I still think that nodes should gossip their bloom filters. If neither a node A, nor its connected peers store the requested content, but some node B on the network has it, we want node A to know about node B with some probability. However, this should be done more carefully. For example, only gossipping bloom filters every N seconds to the network.

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- After receiving a PUT request, a node will no longer gossip its bloom filter to the network
- Instead, a node will send the bloom filter to its connected peers only using the request response behaviour
- If a node receives a bloom filter from a peer, it will store the bloom filter in a map (as before)
- If a peer disconnects, the bloom filter will be removed from the map

## Demo

See the unit test `test_send_cache_summary` .


## Notes
<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->


## Checklist

- [x] I have performed a self-review and commented my code, particularly in complex areas
- [x] I have made corresponding changes to the tests
- [x] I have run the app using my feature and ensured that no functionality is broken
