### PR TITLE
feat: filter peers using cache summary for getbitswap

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -757,10 +757,17 @@ where
                         self.response_channels.insert(cid, vec![sender]);
                     }
 
-                    let query = self
-                        .swarm
-                        .behaviour_mut()
-                        .get_block(cid, peers.iter().copied());
+                    let peers = peers
+                        .iter()
+                        .filter(|peer| {
+                            if let Some(cache_summary) = self.peer_cached_content.get(*peer) {
+                                return cache_summary.contains(&cid.to_bytes());
+                            }
+                            true
+                        })
+                        .copied();
+
+                    let query = self.swarm.behaviour_mut().get_block(cid, peers);
 
                     if let Ok(query_id) = query {
                         self.bitswap_queries.insert(query_id, cid);


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->
At the moment, `GetBitswap` will send requests to all connected peers, which can be inefficient. We therefore want to leverage the cache summaries (bloom filters) sent from the connected peers to filter out peers that definitely don't store the requested content. If there doesn't exist a bloom filter for a connected peer (I cannot think of a case where this happens atm), we still send out the request


## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Filter peers before sending getbitswap request using the bloom filters.

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 



## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->



## Checklist

- [x] I have performed a self-review and commented my code, particularly in complex areas
- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
