### PR TITLE
chore: revert debug trait

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -189,7 +189,7 @@ pub enum NetworkCommand {
 
 pub struct UrsaService<S>
 where
-    S: Blockstore + Clone + Debug + Store + Send + Sync + 'static,
+    S: Blockstore + Clone + Store + Send + Sync + 'static,
 {
     /// Store.
     pub store: Arc<UrsaStore<S>>,
@@ -223,7 +223,7 @@ where
 
 impl<S> UrsaService<S>
 where
-    S: Blockstore + Clone + Debug + Store + Send + Sync + 'static,
+    S: Blockstore + Clone + Store + Send + Sync + 'static,
 {
     /// Init a new [`UrsaService`] based on [`NetworkConfig`]
     ///
@@ -726,10 +726,7 @@ where
                 }
                 Ok(())
             }
-            _ => {
-                debug!("Unhandled swarm event {:?}", event);
-                Ok(())
-            }
+            _ => Ok(()),
         }
     }
 


### PR DESCRIPTION
## Why

Debug trait introduced here 957ed5c92b5a9570cdadc821c571b19698aaf4db. Causes rocksdb mismatch. 

## What

- Remove debug trait

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
