### PR TITLE
feat: gateway cache conditional

### DIFF
--- a/crates/ursa-gateway/example/local.toml
+++ b/crates/ursa-gateway/example/local.toml
@@ -9,6 +9,7 @@ cert_path = ".ursa/gateway/server_cert.pem"
 key_path = ".ursa/gateway/server_key.pem"
 stream_buf = 2000000 # 2mb
 cache_control_max_age = 604800 # one week in second
+cache_control_max_size = 1000000000 # 1GB
 
 [admin_server]
 port = 5001

--- a/crates/ursa-gateway/example/node.toml
+++ b/crates/ursa-gateway/example/node.toml
@@ -9,6 +9,7 @@ cert_path = ".ursa/gateway/server_cert.pem"
 key_path = ".ursa/gateway/server_key.pem"
 stream_buf = 2000000 # 2mb
 cache_control_max_age = 604800 # one week in second
+cache_control_max_size = 1000000000 # 1GB
 
 [admin_server]
 port = 5001

--- a/crates/ursa-gateway/src/cli.rs
+++ b/crates/ursa-gateway/src/cli.rs
@@ -54,6 +54,9 @@ pub struct DaemonCmdOpts {
     /// cache control max age response (second)
     #[arg(long)]
     pub cache_control_max_age: Option<u64>,
+    /// cache control max size response
+    #[arg(long)]
+    pub cache_control_max_size: Option<u64>,
     /// admin port
     #[arg(long)]
     pub admin_port: Option<u16>,

--- a/crates/ursa-gateway/src/config.rs
+++ b/crates/ursa-gateway/src/config.rs
@@ -62,6 +62,7 @@ pub struct ServerConfig {
     pub key_path: PathBuf,
     pub stream_buf: u64,
     pub cache_control_max_age: u64,
+    pub cache_control_max_size: u64,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -103,8 +104,9 @@ impl Default for GatewayConfig {
                 key_path: PathBuf::from(env!("HOME"))
                     .join(DEFAULT_URSA_GATEWAY_PATH)
                     .join("server_key.pem"),
-                stream_buf: 2_000_000,          // 2MB
-                cache_control_max_age: 604_800, // one week
+                stream_buf: 2_000_000,                 // 2MB
+                cache_control_max_age: 604_800,        // one week
+                cache_control_max_size: 1_000_000_000, // 1GB
             },
             admin_server: AdminConfig {
                 addr: "0.0.0.0".into(),
@@ -185,6 +187,9 @@ impl GatewayConfig {
         }
         if let Some(ttl_cache_interval) = config.ttl_cache_interval {
             self.worker.ttl_cache_interval = ttl_cache_interval;
+        }
+        if let Some(cache_control_max_size) = config.cache_control_max_size {
+            self.server.cache_control_max_size = cache_control_max_size;
         }
     }
 }

--- a/crates/ursa-gateway/src/main.rs
+++ b/crates/ursa-gateway/src/main.rs
@@ -72,6 +72,7 @@ async fn main() -> Result<()> {
                 gateway_config.cache.ttl_buf as u128 * 1_000_000, // ms to ns
                 worker_tx.clone(),                                // cache command producer
                 gateway_config.server.stream_buf,
+                gateway_config.server.cache_control_max_size,
             )));
             let server_cache = Arc::clone(&cache);
             let admin_cache = Arc::clone(&server_cache);

--- a/crates/ursa-gateway/src/resolver/mod.rs
+++ b/crates/ursa-gateway/src/resolver/mod.rs
@@ -24,7 +24,7 @@ pub struct Resolver {
 }
 
 #[derive(Debug)]
-pub struct Response {
+pub struct NodeResponse {
     pub resp: response::Response<Body>,
     pub size: u64,
 }
@@ -37,7 +37,7 @@ impl Resolver {
         }
     }
 
-    pub async fn resolve_content(&self, cid: &str) -> Result<Response, Error> {
+    pub async fn resolve_content(&self, cid: &str) -> Result<NodeResponse, Error> {
         let endpoint = format!("{}/{cid}", self.indexer_cid_url);
 
         let uri = endpoint.parse::<Uri>().map_err(|e| {
@@ -172,7 +172,7 @@ impl Resolver {
             };
             match self.client.get(uri).await {
                 Ok(resp) => {
-                    return Ok(Response {
+                    return Ok(NodeResponse {
                         resp,
                         size: metadata.size,
                     })

--- a/crates/ursa-gateway/src/worker/cache/mod.rs
+++ b/crates/ursa-gateway/src/worker/cache/mod.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use opentelemetry::Context;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
-use crate::resolver::Response;
+use crate::resolver::NodeResponse;
 use crate::{
     cache::{ByteSize, Tlrfu},
     util::error::Error,
@@ -58,7 +58,7 @@ pub enum CacheCommand {
     },
     Fetch {
         cid: String,
-        sender: oneshot::Sender<Result<Response, Error>>,
+        sender: oneshot::Sender<Result<NodeResponse, Error>>,
         ctx: Context,
     },
     TtlCleanUp,

--- a/crates/ursa-gateway/src/worker/cache/mod.rs
+++ b/crates/ursa-gateway/src/worker/cache/mod.rs
@@ -24,6 +24,7 @@ pub struct Cache {
     tlrfu: Tlrfu<Bytes>,
     tx: UnboundedSender<CacheCommand>,
     stream_buf: u64,
+    cache_control_max_size: u64,
 }
 
 impl Cache {
@@ -32,11 +33,13 @@ impl Cache {
         ttl_buf: u128,
         tx: UnboundedSender<CacheCommand>,
         stream_buf: u64,
+        cache_control_max_size: u64,
     ) -> Self {
         Self {
             tlrfu: Tlrfu::new(max_size, ttl_buf),
             tx,
             stream_buf,
+            cache_control_max_size,
         }
     }
 }

--- a/crates/ursa-gateway/src/worker/cache/mod.rs
+++ b/crates/ursa-gateway/src/worker/cache/mod.rs
@@ -5,10 +5,10 @@ pub mod worker;
 use std::sync::Arc;
 
 use anyhow::Result;
-use axum::{body::Body, response::Response};
 use bytes::Bytes;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
+use crate::resolver::Response;
 use crate::{
     cache::{ByteSize, Tlrfu},
     util::error::Error,
@@ -52,7 +52,7 @@ pub enum CacheCommand {
     },
     Fetch {
         cid: String,
-        sender: oneshot::Sender<Result<Response<Body>, Error>>,
+        sender: oneshot::Sender<Result<Response, Error>>,
     },
     TtlCleanUp,
 }

--- a/crates/ursa-gateway/src/worker/cache/server.rs
+++ b/crates/ursa-gateway/src/worker/cache/server.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::resolver::Response;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::response::IntoResponse;
@@ -30,10 +29,11 @@ pub trait ServerCache: Send + Sync + 'static {
 impl ServerCache for Cache {
     async fn get_announce(&self, k: &str, no_cache: bool) -> Result<StreamBody, Error> {
         if no_cache {
-            fetch_and_insert(k, &self.tx, self.stream_buf as usize, 69).await
+            fetch(k, &self.tx)
+                .await
+                .map(|(body, _)| StreamBody::Direct(body))
         } else if let Some(data) = self.tlrfu.dirty_get(&String::from(k)) {
             let (mut w, r) = duplex(self.stream_buf as usize);
-
             let data = Arc::clone(data);
             self.tx
                 .send(CacheCommand::GetSync {
@@ -48,9 +48,41 @@ impl ServerCache for Cache {
                     error!("Failed to write to stream: {e:?}");
                 }
             });
-            return Ok(StreamBody::Duplex(r));
+            Ok(StreamBody::Duplex(r))
         } else {
-            fetch_and_insert(k, &self.tx, self.stream_buf as usize, 69).await
+            let (mut body, content_size) = fetch(k, &self.tx).await?;
+            if content_size > 69 {
+                return Ok(StreamBody::Direct(body));
+            }
+            let key = String::from(k); // move to [worker|writer] thread
+            let tx = self.tx.clone(); // move to [worker|writer] thread
+            let (mut w, r) = duplex(self.stream_buf as usize);
+            spawn(async move {
+                let mut bytes = Vec::with_capacity(body.size_hint().lower() as usize);
+                while let Some(buf) = body.data().await {
+                    match buf {
+                        Ok(buf) => {
+                            if let Err(e) = w.write_all(buf.as_ref()).await {
+                                error!("Failed to write to stream for {e:?}");
+                                return;
+                            };
+                            bytes.put(buf);
+                        }
+                        Err(e) => {
+                            error!("Failed to read stream for {e:?}");
+                            return;
+                        }
+                    }
+                }
+                if let Err(e) = tx.send(CacheCommand::InsertSync {
+                    key,
+                    value: Arc::new(bytes.into()),
+                }) {
+                    error!("Failed to dispatch InsertSync command: {e:?}");
+                };
+            });
+
+            Ok(StreamBody::Duplex(r))
         }
     }
 }
@@ -71,7 +103,6 @@ async fn fetch(k: &str, cmd_sender: &UnboundedSender<CacheCommand>) -> Result<(B
         error!("Failed to receive response from resolver: {e:?}");
         anyhow!("Failed to receive response from resolver")
     })??;
-
     let body = match response.resp.into_parts() {
         (
             Parts {
@@ -88,52 +119,7 @@ async fn fetch(k: &str, cmd_sender: &UnboundedSender<CacheCommand>) -> Result<(B
             ));
         }
     };
-
     Ok((body, response.size))
-}
-
-async fn fetch_and_insert(
-    k: &str,
-    cmd_sender: &UnboundedSender<CacheCommand>,
-    stream_buf: usize,
-    max_content_size: u64,
-) -> Result<StreamBody, Error> {
-    let (mut body, content_size) = fetch(k, cmd_sender).await?;
-
-    if content_size > max_content_size {
-        return Ok(StreamBody::Direct(body));
-    }
-
-    let (mut stream_writer, r) = duplex(stream_buf);
-
-    let key = String::from(k); // move to [worker|writer] thread
-    let tx = cmd_sender.clone(); // move to [worker|writer] thread
-    spawn(async move {
-        let mut bytes = Vec::with_capacity(body.size_hint().lower() as usize);
-        while let Some(buf) = body.data().await {
-            match buf {
-                Ok(buf) => {
-                    if let Err(e) = stream_writer.write_all(buf.as_ref()).await {
-                        error!("Failed to write to stream for {e:?}");
-                        return;
-                    };
-                    bytes.put(buf);
-                }
-                Err(e) => {
-                    error!("Failed to read stream for {e:?}");
-                    return;
-                }
-            }
-        }
-        if let Err(e) = tx.send(CacheCommand::InsertSync {
-            key,
-            value: Arc::new(bytes.into()),
-        }) {
-            error!("Failed to dispatch InsertSync command: {e:?}");
-        };
-    });
-
-    Ok(StreamBody::Duplex(r))
 }
 
 pub enum StreamBody {

--- a/crates/ursa-gateway/src/worker/cache/server.rs
+++ b/crates/ursa-gateway/src/worker/cache/server.rs
@@ -15,7 +15,7 @@ use tokio::{
     sync::{mpsc::UnboundedSender, oneshot},
 };
 use tokio_util::io::ReaderStream;
-use tracing::error;
+use tracing::{error, info};
 
 use super::{Cache, CacheCommand};
 use crate::util::error::Error;
@@ -52,6 +52,7 @@ impl ServerCache for Cache {
         } else {
             let (mut body, content_size) = fetch(k, &self.tx).await?;
             if content_size > 69 {
+                info!("Content size is {content_size}...skipping cache");
                 return Ok(StreamBody::Direct(body));
             }
             let key = String::from(k); // move to [worker|writer] thread

--- a/crates/ursa-gateway/src/worker/cache/server.rs
+++ b/crates/ursa-gateway/src/worker/cache/server.rs
@@ -51,7 +51,7 @@ impl ServerCache for Cache {
             Ok(StreamBody::Duplex(r))
         } else {
             let (mut body, content_size) = fetch(k, &self.tx).await?;
-            if content_size > 69 {
+            if content_size > self.cache_control_max_size {
                 info!("Content size is {content_size}...skipping cache");
                 return Ok(StreamBody::Direct(body));
             }

--- a/crates/ursa-gateway/src/worker/cache/server.rs
+++ b/crates/ursa-gateway/src/worker/cache/server.rs
@@ -74,14 +74,11 @@ async fn fetch_and_insert(
             error!("Failed to dispatch Fetch command: {e:?}");
             anyhow!("Failed to dispatch Fetch command")
         })?;
-    let mut body = match rx
-        .await
-        .map_err(|e| {
-            error!("Failed to receive response from resolver: {e:?}");
-            anyhow!("Failed to receive response from resolver")
-        })??
-        .into_parts()
-    {
+    let response = rx.await.map_err(|e| {
+        error!("Failed to receive response from resolver: {e:?}");
+        anyhow!("Failed to receive response from resolver")
+    })??;
+    let mut body = match response.resp.into_parts() {
         (
             Parts {
                 status: StatusCode::OK,


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->
We don't want to cache if the content is too large.


Fixes #210 

## What

<!-- Please include a bulleted list of what the pull request is changing --->
Stream directly from node to client.

## Demo
Set `cache_control_max_size = 27000 `

Input:
> -rw-r--r--   1 acadia  staff   27044 Dec 18 16:50 basic.car

Command:
> curl https://0.0.0.0:80/bafybeifyjj2bjhtxmp235vlfeeiy7sz6rzyx3lervfk3ap2nyn4rggqgei 

Output:
```
  2023-01-13T20:36:44.316160Z  INFO ursa_gateway::worker::cache::server: Content size is 27044...skipping cache
    at crates/ursa-gateway/src/worker/cache/server.rs:64
    in ursa_gateway::worker::cache::server::Cache missed
    in ursa_gateway::server::route::api::v1::get::Get car handler
    in axum_tracing_opentelemetry::middleware::trace_extractor::HTTP request with otel.name: GET /:cid, http.client_ip: , http.flavor: 2.0, http.host: , http.method: GET, http.route: /:cid, http.scheme: https, http.target: /bafybeifyjj2bjhtxmp235vlfeeiy7sz6rzyx3lervfk3ap2nyn4rggqgei, http.user_agent: curl/7.84.0, otel.kind: server, trace_id: 52b1d942d75ede5a77c7ef6d525f94ea


```


## Checklist

- N/A I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
