### PR TITLE
chore: info to debug logs

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -519,7 +519,7 @@ where
                         peer,
                         num_remaining,
                     }) => {
-                        info!(
+                        debug!(
                             "[KademliaEvent::Bootstrap] - Received peer: {peer:?}, {}",
                             match num_remaining {
                                 0 => "bootstrap complete!".into(),
@@ -533,7 +533,7 @@ where
                 },
                 other => debug!("[KademliaEvent::OutboundQueryProgressed] - {id:?}: {other:?}"),
             },
-            _ => info!("[KademliaEvent] - {event:?}"),
+            _ => debug!("[KademliaEvent] - {event:?}"),
         }
         Ok(())
     }

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -88,6 +88,7 @@ pub trait NetworkInterface: Sync + Send + 'static {
     // get the addrresses that p2p node is listening on
     async fn get_listener_addresses(&self) -> Result<Vec<Multiaddr>>;
 }
+
 #[derive(Clone)]
 pub struct NodeNetworkInterface<S>
 where


### PR DESCRIPTION
## Why
Kademlia can be too verbose


Fixes # (issue)

- Change `info` to `debug` logs

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
