### PR TITLE
chore: use localized workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,11 @@ exclude = [
   "test-plans",
 ]
 
-[profile.release]
-# 2 full, 0 nothing, 1 good enough.
-debug = 1
-# currently enabled, may increase build time, but runtime faster, can set to `"thin"`.
-lto = true
-# optimize for binary size, but also turn off loop vectorization.
-opt-level = 'z'
-# speeds up build time to offset some of the link time optimization.
-codegen-units = 1
-# strip debug info from binary.
-strip = 'debuginfo'
-# On panic terminate the process.
-panic = 'abort'
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0/MIT"
+repository = "https://github.com/fleek-network/ursa"
 
 [workspace.dependencies]
 anyhow = "1.0.67"
@@ -96,3 +88,17 @@ tracing-tree = "0.2.2"
 tracing-chrome = "0.7.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 axum-tracing-opentelemetry = "0.7.4"
+
+[profile.release]
+# 2 full, 0 nothing, 1 good enough.
+debug = 1
+# currently enabled, may increase build time, but runtime faster, can set to `"thin"`.
+lto = true
+# optimize for binary size, but also turn off loop vectorization.
+opt-level = 'z'
+# speeds up build time to offset some of the link time optimization.
+codegen-units = 1
+# strip debug info from binary.
+strip = 'debuginfo'
+# On panic terminate the process.
+panic = 'abort'

--- a/crates/ursa-gateway/Cargo.toml
+++ b/crates/ursa-gateway/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-gateway"
-version = "0.1.0"
-edition = "2021"
 authors = ["b0xtch <mahmoud@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's proxy gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-index-provider/Cargo.toml
+++ b/crates/ursa-index-provider/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ursa-index-provider"
-version = "0.1.0"
-edition = "2021"
+authors = ["theBeardA <arslan@fleek.co>"]
+description = "Ursa's global index provider"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-metrics/Cargo.toml
+++ b/crates/ursa-metrics/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-metrics"
-version = "0.1.0"
-edition = "2021"
 authors = ["ossian <oz@fleek.xyz>", "mtavano <marcello@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa metrics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 lazy_static.workspace = true

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-network"
-version = "0.1.0"
-edition = "2021"
 authors = ["b0xtch <mahmoud@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's libp2p implementation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-rpc-service/Cargo.toml
+++ b/crates/ursa-rpc-service/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-rpc-service"
-version = "0.1.0"
-edition = "2021"
 authors = ["b0xtch <mahmoud@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's multiplex server implementation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-store/Cargo.toml
+++ b/crates/ursa-store/Cargo.toml
@@ -1,12 +1,12 @@
 
 [package]
 name = "ursa-store"
-version = "0.1.0"
-edition = "2021"
 authors = ["b0xtch <mahmoud@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's store implementation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-telemetry/Cargo.toml
+++ b/crates/ursa-telemetry/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-telemetry"
-version = "0.1.0"
-edition = "2021"
 authors = ["b0xtch <mahmoud@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/Psychedelic/ursa"
 description = "Ursa's Telemetry crate"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ursa-tracker/Cargo.toml
+++ b/crates/ursa-tracker/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa-tracker"
-version = "0.1.0"
-edition = "2021"
 authors = ["ossian <oz@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's pre-consensus node tracker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 geohash = "0.12.0"

--- a/crates/ursa/Cargo.toml
+++ b/crates/ursa/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ursa"
-version = "0.1.0"
-edition = "2021"
 authors = ["theBeardA <arslan@fleek.co>"]
-license = "MIT"
-repository = "https://github.com/fleek-network/ursa"
 description = "Ursa's cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Why
Localize all package related info to top-level workspace

Fixes # (issue)

- Change all crates to use top level workspace.package info