### PR TITLE
fix(gateway): prevent server stop when request canceling

### DIFF
--- a/crates/ursa-gateway/src/resolver/mod.rs
+++ b/crates/ursa-gateway/src/resolver/mod.rs
@@ -1,8 +1,15 @@
 pub mod model;
 
 use anyhow::{anyhow, Context};
-use axum::{body::Body, http::response, http::response::Parts};
-use hyper::{body::to_bytes, client::HttpConnector, StatusCode, Uri};
+use axum::{
+    body::Body,
+    http::response::{Parts, Response},
+};
+use hyper::{
+    body::to_bytes,
+    client::{self, HttpConnector},
+    StatusCode, Uri,
+};
 use hyper_tls::HttpsConnector;
 use libp2p::multiaddr::Protocol;
 use model::IndexerResponse;
@@ -16,7 +23,7 @@ use crate::{
 
 const FLEEK_NETWORK_FILTER: &[u8] = b"FleekNetwork";
 
-type Client = hyper::client::Client<HttpsConnector<HttpConnector>, Body>;
+type Client = client::Client<HttpsConnector<HttpConnector>, Body>;
 
 pub struct Resolver {
     indexer_cid_url: String,
@@ -25,7 +32,7 @@ pub struct Resolver {
 
 #[derive(Debug)]
 pub struct NodeResponse {
-    pub resp: response::Response<Body>,
+    pub resp: Response<Body>,
     pub size: u64,
 }
 

--- a/crates/ursa-gateway/src/server/route/api/v1/get.rs
+++ b/crates/ursa-gateway/src/server/route/api/v1/get.rs
@@ -31,7 +31,6 @@ pub async fn get_car_handler<Cache: ServerCache>(
         )
         .into_response();
     };
-
     let no_cache = cache_control.map_or(false, |c| c.no_cache());
     match cache
         .read()

--- a/crates/ursa-gateway/src/worker/cache/mod.rs
+++ b/crates/ursa-gateway/src/worker/cache/mod.rs
@@ -9,9 +9,9 @@ use bytes::Bytes;
 use opentelemetry::Context;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
-use crate::resolver::NodeResponse;
 use crate::{
     cache::{ByteSize, Tlrfu},
+    resolver::NodeResponse,
     util::error::Error,
 };
 


### PR DESCRIPTION
## Why
Prevent the server from stopping when request canceling.


Fixes:
- Solved: https://github.com/fleek-network/ursa/issues/289#issuecomment-1385797903
- Related: #289 

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Reduce log level.
- Not stop the server.

## Demo

N/A


## Notes

N/A


## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
