### PR TITLE
feat: track duration of pull test plan

### DIFF
--- a/test-plans/data-transfer/src/main.rs
+++ b/test-plans/data-transfer/src/main.rs
@@ -34,9 +34,11 @@ async fn main() {
     // All nodes wait here and signal to the bootstrap node that they are done.
     client.signal_and_wait("done", num_nodes).await.unwrap();
 
-    if let Err(e) = result {
-        client.record_failure(e).await.expect("Success");
-    } else {
-        client.record_success().await.expect("Success");
+    match result {
+        Ok((test_name, duration)) => {
+            client.record_message(format!("{test_name}: {duration:?}"));
+            client.record_success().await.expect("Success")
+        }
+        Err(e) => client.record_failure(e).await.expect("Success"),
     }
 }

--- a/test-plans/data-transfer/src/pull.rs
+++ b/test-plans/data-transfer/src/pull.rs
@@ -58,7 +58,7 @@ pub async fn run_test(client: &mut Client, node: Node) -> Result<(String, Durati
     let duration = Instant::now().duration_since(start);
     // Let's wait until everyone is done.
     client
-        .signal_and_wait("test_cache_request_done", num_nodes)
+        .signal_and_wait("pull-test-done", num_nodes)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->
We need this data for bench marking. 

Fixes #264 

## What

<!-- Please include a bulleted list of what the pull request is changing --->

Track duration of pull test plan.

## Demo

```
Jan 17 18:51:54.781754	INFO	45.8881s         OK << data-transfer[008] (768df5) >> 
Jan 17 18:51:54.781843	INFO	0.0000s    MESSAGE << data-transfer[007] (0182f6) >> [Pull] Results for node 6: 5.002273377s
Jan 17 18:51:54.781895	INFO	0.0000s    MESSAGE << data-transfer[004] (c54211) >> [Pull] Results for node 3: 5.001265294s
Jan 17 18:51:54.781929	INFO	45.8866s         OK << data-transfer[007] (0182f6) >> 
Jan 17 18:51:54.781951	INFO	45.8876s         OK << data-transfer[004] (c54211) >> 
Jan 17 18:51:54.781754	INFO	0.0000s    MESSAGE << data-transfer[006] (9131bb) >> [Pull] Results for node 9: 5.001424878s
Jan 17 18:51:54.781990	INFO	0.0000s    MESSAGE << data-transfer[003] (ee6a2f) >> [Pull] Results for node 8: 5.001309753s
Jan 17 18:51:54.782018	INFO	45.8872s         OK << data-transfer[006] (9131bb) >> 
Jan 17 18:51:54.782040	INFO	45.8892s         OK << data-transfer[003] (ee6a2f) >> 
Jan 17 18:51:54.782078	INFO	0.0000s    MESSAGE << data-transfer[000] (e4682b) >> [Pull] Results for node 4: 5.001620169s
Jan 17 18:51:54.782642	INFO	45.8882s         OK << data-transfer[000] (e4682b) >> 
Jan 17 18:51:54.782079	INFO	0.0000s    MESSAGE << data-transfer[002] (a55890) >> [Pull] Results for node 7: 5.000691544s
Jan 17 18:51:54.782707	INFO	45.8909s         OK << data-transfer[002] (a55890) >> 
Jan 17 18:51:54.782116	INFO	0.0000s    MESSAGE << data-transfer[009] (c99c2f) >> [Pull] Results for node 5: 5.001090044s
Jan 17 18:51:54.782764	INFO	45.8872s         OK << data-transfer[009] (c99c2f) >> 
Jan 17 18:51:54.782153	INFO	0.0000s    MESSAGE << data-transfer[005] (9bbe14) >> [Pull] Results for node 10: 5.00520721s
Jan 17 18:51:54.782923	INFO	45.9052s         OK << data-transfer[005] (9bbe14) >> 
Jan 17 18:51:54.782189	INFO	0.0000s    MESSAGE << data-transfer[001] (2b8664) >> [Pull] Results for node 2: 7.119375ms
Jan 17 18:51:54.783001	INFO	45.8899s         OK << data-transfer[001] (2b8664) >> 
```

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->



## Checklist

- N/A I have made corresponding changes to the tests
- N/A I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
