### PR TITLE
fix: use bitswap sync to fetch dag

### DIFF
--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -762,9 +762,10 @@ where
                             }
                             true
                         })
-                        .copied();
+                        .copied()
+                        .collect();
 
-                    let query = self.swarm.behaviour_mut().get_block(cid, peers);
+                    let query = self.swarm.behaviour_mut().sync_block(cid, peers);
 
                     if let Ok(query_id) = query {
                         self.bitswap_queries.insert(query_id, cid);

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -424,7 +424,7 @@ async fn test_bitswap_sync() -> Result<()> {
     match res {
         Ok(_) => {
             for cid in cids_vec {
-                assert!(bitswap_store_2.contains(&cid).is_ok());
+                assert!(bitswap_store_2.contains(&cid).unwrap());
             }
         }
         Err(e) => panic!("{e:?}"),


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->
We are currently using `Bitswap::get` which fetches individual blocks. 

Fixes #300 

## What

<!-- Please include a bulleted list of what the pull request is changing --->

Use `Bitswap::sync`.


## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have run the app using my feature and ensured that no functionality is broken
