### PR TITLE
fix: prevent fvm version from deprecated

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           brew update
           brew install protobuf
-          protoc --version      
+          protoc --version
 
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -70,7 +70,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -117,10 +117,10 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-          
+
       - run: cargo test --workspace --all-features
       - run: cargo test --workspace --no-default-features
 
@@ -171,13 +171,13 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo clippy --workspace --all-targets
-      - run: cargo clippy --workspace --all-targets --no-default-features
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rustfmt:
     name: Code formatting
@@ -215,7 +215,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ futures = "0.3.25"
 futures-util = "0.3.25"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_car = "0.6.0"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "=0.3.2"
 graphsync = { git = "https://github.com/kckeiks/rs-graphsync.git",  branch = "downgrade-cid" }
 hyper = { version = "0.14.23", features = ["full"] }
 hyper-tls = "0.5.0"

--- a/crates/ursa-index-provider/src/tests/mod.rs
+++ b/crates/ursa-index-provider/src/tests/mod.rs
@@ -59,7 +59,7 @@ pub fn provider_engine_init(
     let router = provider_engine.router();
     task::spawn(async move {
         // startup standalone http server for index provider
-        axum::Server::bind(&SocketAddr::from_str(&format!("0.0.0.0:{}", port)).unwrap())
+        axum::Server::bind(&SocketAddr::from_str(&format!("0.0.0.0:{port}")).unwrap())
             .serve(router.into_make_service())
             .await
             .expect("Failed to start provider server");


### PR DESCRIPTION
## Why

Deprecating from fvm latest version.


## What

Exact version of fvm

## Demo

N/A

## Notes

N/A

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
