### PR TITLE
chore: domain migration to `server_config` from `provider_config`

### DIFF
--- a/crates/ursa-index-provider/src/config.rs
+++ b/crates/ursa-index-provider/src/config.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderConfig {
-    /// a domain where the node is listening, eg. `dns/test-node.ursa.earth`
+    /// ! Deprecated ! Moved to `ursa-rpc-service` config.
+    /// Left here for backwards compatability; so that configs can be migrated
     #[serde(default)]
-    pub domain: String,
+    pub domain: Option<String>,
     /// indexer url to point to, eg. https://dev.cid.contact
     #[serde(default = "ProviderConfig::default_indexer_url")]
     pub indexer_url: String,
@@ -26,7 +27,7 @@ impl ProviderConfig {
 impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
-            domain: "".to_string(),
+            domain: None,
             indexer_url: Self::default_indexer_url(),
             database_path: Self::default_database_path(),
         }

--- a/crates/ursa-index-provider/src/engine.rs
+++ b/crates/ursa-index-provider/src/engine.rs
@@ -93,6 +93,7 @@ pub struct ProviderEngine<S> {
     network_command_sender: Sender<NetworkCommand>,
     /// Server from which advertised content is retrievable.
     server_address: Multiaddr,
+    domain: Multiaddr,
 }
 
 impl<S> ProviderEngine<S>
@@ -106,6 +107,7 @@ where
         config: ProviderConfig,
         network_command_sender: Sender<NetworkCommand>,
         server_address: Multiaddr,
+        domain: Multiaddr,
     ) -> Self {
         let (command_sender, command_receiver) = unbounded_channel();
         ProviderEngine {
@@ -116,6 +118,7 @@ where
             provider: Provider::new(keypair, provider_store),
             store,
             server_address,
+            domain,
         }
     }
     pub fn command_sender(&self) -> Sender<ProviderCommand> {
@@ -163,7 +166,7 @@ where
                         } else {
                             match self
                                 .provider
-                                .create_announce_message(peer_id, self.config.domain.clone())
+                                .create_announce_message(peer_id, self.domain.clone())
                             {
                                 Ok(announce_message) => {
                                     if let Err(e) = self

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -14,6 +14,7 @@ use fvm_ipld_encoding::Cbor;
 use libipld::codec::Encode;
 use libipld_cbor::DagCborCodec;
 use libipld_core::{ipld::Ipld, serde::to_ipld};
+use libp2p::multiaddr::Protocol;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use rand;
 use rand::Rng;
@@ -21,7 +22,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     io::Write,
-    str::FromStr,
     sync::{Arc, RwLock},
 };
 use tracing::{info, trace};
@@ -104,7 +104,7 @@ pub trait ProviderInterface: Sync + Send + 'static {
     fn create(&mut self, ad: Advertisement) -> Result<usize>;
     fn add_chunk(&mut self, bytes: Vec<u8>, id: usize) -> Result<()>;
     fn publish(&mut self, id: usize) -> Result<Advertisement>;
-    fn create_announce_message(&mut self, peer_id: PeerId, domain: String) -> Result<Vec<u8>>;
+    fn create_announce_message(&mut self, peer_id: PeerId, domain: Multiaddr) -> Result<Vec<u8>>;
 }
 
 impl<S> ProviderInterface for Provider<S>
@@ -158,17 +158,15 @@ where
         Err(anyhow!("ad not found"))
     }
 
-    fn create_announce_message(&mut self, peer_id: PeerId, mut domain: String) -> Result<Vec<u8>> {
-        if domain.is_empty() {
-            domain = "/ip4/127.0.0.1/tcp/4069".to_string();
-        }
-        let mut multiaddrs = Multiaddr::from_str(&domain)?;
-        multiaddrs = Multiaddr::try_from(format!("{multiaddrs}/http/p2p/{peer_id}"))?;
-        let message_addrs = [multiaddrs].to_vec();
+    fn create_announce_message(&mut self, peer_id: PeerId, domain: Multiaddr) -> Result<Vec<u8>> {
+        let mut multiaddr = domain;
+        multiaddr.push(Protocol::Http);
+        multiaddr.push(Protocol::P2p(peer_id.into()));
+
         if let Some(head_cid) = *self.head.read().unwrap() {
             let message = Message {
                 Cid: head_cid,
-                Addrs: message_addrs,
+                Addrs: vec![multiaddr],
                 ExtraData: *b"",
             };
 

--- a/crates/ursa-index-provider/src/tests/mod.rs
+++ b/crates/ursa-index-provider/src/tests/mod.rs
@@ -54,6 +54,7 @@ pub fn provider_engine_init(
         ProviderConfig::default(),
         service.command_sender(),
         server_address,
+        "/ip4/127.0.0.1/tcp/4069".parse().unwrap(),
     );
 
     let router = provider_engine.router();

--- a/crates/ursa-rpc-service/src/config.rs
+++ b/crates/ursa-rpc-service/src/config.rs
@@ -1,9 +1,15 @@
+use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ServerConfig {
+    /// Domain Multiaddress of the node, eg. `/dns/test-node.ursa.earth`
+    #[serde(default = "ServerConfig::default_domain")]
+    pub domain: Multiaddr,
+    /// Port to listen on
     #[serde(default = "ServerConfig::default_port")]
     pub port: u16,
+    /// Address to bind to
     #[serde(default = "ServerConfig::default_addr")]
     pub addr: String,
     #[serde(default)]
@@ -11,6 +17,9 @@ pub struct ServerConfig {
 }
 
 impl ServerConfig {
+    fn default_domain() -> Multiaddr {
+        "/ip4/127.0.0.1/tcp/4069".parse().unwrap()
+    }
     fn default_port() -> u16 {
         4069
     }
@@ -22,6 +31,7 @@ impl ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            domain: Self::default_domain(),
             port: Self::default_port(),
             addr: Self::default_addr(),
             origin: Default::default(),
@@ -31,6 +41,7 @@ impl Default for ServerConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct OriginConfig {
+    /// Ipfs gateway url
     #[serde(default = "OriginConfig::default_ipfs_gateway")]
     pub ipfs_gateway: String,
     /// Intended for testing purposes

--- a/crates/ursa-rpc-service/src/tests/mod.rs
+++ b/crates/ursa-rpc-service/src/tests/mod.rs
@@ -53,6 +53,7 @@ pub fn init() -> InitResult {
         ProviderConfig::default(),
         service.command_sender(),
         server_address,
+        "/ip4/127.0.0.1/tcp/4069".parse().unwrap(),
     );
 
     Ok((service, provider_engine, store))

--- a/crates/ursa/src/config.rs
+++ b/crates/ursa/src/config.rs
@@ -34,7 +34,15 @@ impl UrsaConfig {
             let mut raw = String::new();
             file.read_to_string(&mut raw)?;
 
-            let config: UrsaConfig = toml::from_str(&raw).context("Failed to parse config file")?;
+            let mut config: UrsaConfig =
+                toml::from_str(&raw).context("Failed to parse config file")?;
+
+            // TEMP: remove this after some time
+            if let Some(domain) = config.provider_config.domain.clone() {
+                warn!("Config `provider_config.domain` depreciated, moving value to `server_config.domain`");
+                config.server_config.domain = domain.parse().unwrap();
+                config.provider_config.domain = None;
+            }
 
             // check if we modified the config at all
             let config_str = toml::to_string(&config)?;

--- a/crates/ursa/src/main.rs
+++ b/crates/ursa/src/main.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
                     provider_config,
                     service.command_sender(),
                     server_address,
+                    server_config.domain.clone(),
                 );
                 let index_provider_router = index_provider_engine.router();
 


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->

First part of migrating domain from provider_config -> server_config. After some time the provider config field and migration logic can be removed completely

Fixes #244 

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- add server_config.domain
- make old provider_config.domain optional 
- when loading an existing file, and the field is populated, move it to new location

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

![image](https://user-images.githubusercontent.com/8976745/214218457-baafab18-6034-4698-99e2-735ce9396e92.png)

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

- After some time, `provider_config.domain` can be completely removed
- I set the default value for domain to be `ip4/127.0.0.1/tcp/4069` for new nodes, so as to have a concrete `Multiaddr` type for the domain field. The side effect of new nodes getting this value may not be desired and if not, I can set the type back to string and have it default as empty

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
