### PR TITLE
chore: import cid from libipld

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 base64 = "0.13.0"
 bincode = "1.3.3"
 bytes = "1.3.0"
-cid = "0.8.6"
 clap = { version = "4.0.29", features = ["derive"] }
 console-subscriber = "0.1.8"
 ctrlc = "3.2.4"
@@ -53,7 +52,7 @@ hyper-tls = "0.5.0"
 imara-diff = "0.1.5"
 jsonrpc-v2 = "0.11.0"
 lazy_static = "1.4"
-libipld = "0.14.0"
+libipld = { version = "0.14.0", features = ["serde-codec"] }
 libipld-core = "0.14.0"
 libp2p = { version = "0.50.0", default-features = false }
 libp2p-bitswap = "0.25.0"

--- a/crates/ursa-gateway/Cargo.toml
+++ b/crates/ursa-gateway/Cargo.toml
@@ -16,10 +16,10 @@ bincode.workspace = true
 base64.workspace = true
 tower = { workspace = true, features = ["full"] }
 tower-http = { workspace = true, features = ["full"] }
-cid.workspace = true
 clap.workspace = true
 hyper.workspace = true
 hyper-tls.workspace = true
+libipld.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/ursa-gateway/src/server/route/api/v1/get.rs
+++ b/crates/ursa-gateway/src/server/route/api/v1/get.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Extension, Json, TypedHeader,
 };
-use cid::Cid;
+use libipld::Cid;
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tracing::{info_span, Instrument};

--- a/crates/ursa-index-provider/Cargo.toml
+++ b/crates/ursa-index-provider/Cargo.toml
@@ -16,7 +16,6 @@ tracing-subscriber.workspace = true
 base64.workspace = true
 bincode.workspace = true
 bytes.workspace = true
-cid.workspace = true
 db.workspace = true
 dirs.workspace = true
 futures.workspace = true

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -1,4 +1,4 @@
-use cid::multihash::{Code, MultihashDigest};
+use libipld::multihash::{Code, MultihashDigest};
 use libipld_core::ipld::Ipld;
 use libp2p::{
     core::{signed_envelope, SignedEnvelope},

--- a/crates/ursa-index-provider/src/engine.rs
+++ b/crates/ursa-index-provider/src/engine.rs
@@ -16,10 +16,10 @@ use ursa_network::{GossipsubMessage, NetworkCommand};
 use anyhow::{anyhow, Error, Result};
 
 use axum::{body::Body, extract::Path, response::Response, routing::get, Extension, Json, Router};
-use cid::Cid;
 
 use crate::provider::ProviderError;
 use fvm_ipld_blockstore::Blockstore;
+use libipld::Cid;
 use libp2p::{gossipsub::TopicHash, identity::Keypair, multiaddr::Protocol, Multiaddr, PeerId};
 use std::{collections::VecDeque, str::FromStr, sync::Arc};
 use tracing::{error, info, warn};

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -8,10 +8,9 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use cid::{multihash::Code, Cid};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::Cbor;
-use libipld::codec::Encode;
+use libipld::{codec::Encode, multihash::Code, Cid};
 use libipld_cbor::DagCborCodec;
 use libipld_core::{ipld::Ipld, serde::to_ipld};
 use libp2p::{identity::Keypair, Multiaddr, PeerId};

--- a/crates/ursa-index-provider/src/signed_head.rs
+++ b/crates/ursa-index-provider/src/signed_head.rs
@@ -1,7 +1,7 @@
 // https://github.com/MarcoPolo/http-index-provider-example/blob/main/src/signed_head.rs
 
 use base64;
-use cid::Cid;
+use libipld::{cid, Cid};
 use libp2p::{
     core::{identity::Keypair, PublicKey},
     identity::error::SigningError,

--- a/crates/ursa-index-provider/src/tests/provider_tests.rs
+++ b/crates/ursa-index-provider/src/tests/provider_tests.rs
@@ -6,7 +6,7 @@ mod tests {
     };
 
     use anyhow::Error;
-    use cid::multihash::{Code, MultihashDigest};
+    use libipld::multihash::{Code, MultihashDigest};
     use libipld_core::ipld::Ipld;
     use surf::Error as SurfError;
     use tokio::task;

--- a/crates/ursa-index-provider/src/tests/signed_head_tests.rs
+++ b/crates/ursa-index-provider/src/tests/signed_head_tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use cid::Cid;
+    use libipld::Cid;
     use libp2p::identity::Keypair;
 
     use crate::signed_head::SignedHead;

--- a/crates/ursa-network/Cargo.toml
+++ b/crates/ursa-network/Cargo.toml
@@ -13,7 +13,6 @@ async-fs.workspace = true
 async-trait.workspace = true
 bincode.workspace = true
 bytes.workspace = true
-cid.workspace = true
 db.workspace = true
 dirs.workspace = true
 fastmurmur3.workspace = true

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -14,11 +14,10 @@
 //!   sent over a new substream on a connection.
 
 use anyhow::Result;
-use cid::Cid;
 use db::Store;
 use fvm_ipld_blockstore::Blockstore;
 use graphsync::GraphSync;
-use libipld::store::StoreParams;
+use libipld::{store::StoreParams, Cid};
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     autonat::{Behaviour as Autonat, Config as AutonatConfig},

--- a/crates/ursa-network/src/codec/protocol.rs
+++ b/crates/ursa-network/src/codec/protocol.rs
@@ -1,7 +1,7 @@
 use crate::utils::cache_summary::CacheSummary;
 use async_trait::async_trait;
-use cid::Cid;
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use libipld::Cid;
 use libp2p::{
     core::{
         upgrade::{read_length_prefixed, write_length_prefixed},

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -13,14 +13,13 @@
 
 use anyhow::{anyhow, Error, Result};
 use bytes::Bytes;
-use cid::Cid;
 use db::Store;
 use fnv::FnvHashMap;
 use futures_util::stream::StreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use graphsync::{GraphSyncEvent, Request};
 use ipld_traversal::{selector::RecursionLimit, Selector};
-use libipld::DefaultParams;
+use libipld::{Cid, DefaultParams};
 use libp2p::{
     autonat::{Event as AutonatEvent, NatStatus},
     gossipsub::{

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -7,13 +7,12 @@ use crate::{
 use anyhow::Result;
 use async_fs::File;
 use bytes::Bytes;
-use cid::{multihash::Code, Cid};
 use db::MemoryDB;
 use futures::io::BufReader;
 use futures::StreamExt;
 use fvm_ipld_car::{load_car, CarReader};
 use ipld_traversal::blockstore::Blockstore;
-use libipld::{cbor::DagCborCodec, ipld, Block, DefaultParams, Ipld};
+use libipld::{cbor::DagCborCodec, ipld, multihash::Code, Block, Cid, DefaultParams, Ipld};
 use libp2p::kad::{BootstrapOk, KademliaEvent, QueryResult};
 use libp2p::request_response::RequestResponseEvent;
 use libp2p::{

--- a/crates/ursa-rpc-service/Cargo.toml
+++ b/crates/ursa-rpc-service/Cargo.toml
@@ -14,7 +14,6 @@ async-trait.workspace = true
 axum.workspace = true
 tracing-subscriber.workspace = true
 bytes.workspace = true
-cid.workspace = true
 db.workspace = true
 fnv.workspace = true
 futures.workspace = true

--- a/crates/ursa-rpc-service/src/api.rs
+++ b/crates/ursa-rpc-service/src/api.rs
@@ -2,13 +2,13 @@ use anyhow::{anyhow, Result};
 use async_fs::{create_dir_all, File};
 use async_trait::async_trait;
 use axum::body::StreamBody;
-use cid::Cid;
 use db::Store;
 use futures::channel::mpsc::unbounded;
 use futures::io::BufReader;
 use futures::{AsyncRead, AsyncWriteExt, SinkExt};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::{load_car, CarHeader, CarReader};
+use libipld::Cid;
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use std::collections::{

--- a/crates/ursa-rpc-service/src/http/routes/network.rs
+++ b/crates/ursa-rpc-service/src/http/routes/network.rs
@@ -8,11 +8,11 @@ use axum::{
     routing::{get, post},
     Extension, Json, Router,
 };
-use cid::Cid;
 use db::Store;
 use futures::io::Cursor;
 use fvm_ipld_blockstore::Blockstore;
 use hyper::StatusCode;
+use libipld::Cid;
 use std::{str::FromStr, sync::Arc};
 use tokio::task;
 use tower_http::limit::RequestBodyLimitLayer;

--- a/crates/ursa-rpc-service/src/rpc/routes/network.rs
+++ b/crates/ursa-rpc-service/src/rpc/routes/network.rs
@@ -3,7 +3,7 @@ use axum::{
     routing::{post, put},
     Router,
 };
-use cid::Cid;
+use libipld::Cid;
 use std::{str::FromStr, sync::Arc};
 use ursa_metrics::middleware::track_metrics;
 

--- a/crates/ursa-store/Cargo.toml
+++ b/crates/ursa-store/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 anyhow.workspace = true
 async-fs = "1.6.0"
 async-trait.workspace = true
-cid.workspace = true
 db.workspace = true
 fnv.workspace = true
 futures.workspace = true

--- a/crates/ursa-store/src/store.rs
+++ b/crates/ursa-store/src/store.rs
@@ -1,8 +1,4 @@
 use anyhow::anyhow;
-use cid::{
-    multihash::{Code, MultihashDigest},
-    Cid,
-};
 use db::Store;
 use fnv::FnvHashSet;
 use fvm_ipld_blockstore::Blockstore;
@@ -10,7 +6,12 @@ use fvm_ipld_car::CarHeader;
 use fvm_ipld_encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec, DAG_CBOR};
 use integer_encoding::VarInt;
 use ipld_traversal::blockstore::Blockstore as GSBlockstore;
-use libipld::{store::DefaultParams, Block, Result};
+use libipld::{
+    cid,
+    multihash::{Code, MultihashDigest},
+    store::DefaultParams,
+    Block, Cid, Result,
+};
 use libp2p_bitswap::BitswapStore;
 use std::sync::Arc;
 

--- a/crates/ursa-store/src/tests/store_tests.rs
+++ b/crates/ursa-store/src/tests/store_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use async_fs::File;
-    use cid::Cid;
     use futures::io::BufReader;
     use fvm_ipld_car::{load_car, CarReader};
+    use libipld::Cid;
     use std::path::Path;
     use std::sync::Arc;
 

--- a/test-plans/data-transfer/Cargo.toml
+++ b/test-plans/data-transfer/Cargo.toml
@@ -4,7 +4,6 @@ name = "data-transfer"
 version = "0.1.0"
 
 [dependencies]
-cid = "0.8.6"
 env_logger = "0.9.0"
 if-addrs = "0.7.0"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", branch = "downgrade-cid" }

--- a/test-plans/data-transfer/src/pull.rs
+++ b/test-plans/data-transfer/src/pull.rs
@@ -1,7 +1,6 @@
 use crate::node::Node;
-use cid::multihash::Code;
 use ipld_traversal::blockstore::Blockstore;
-use libipld::{cbor::DagCborCodec, ipld, Block, DefaultParams};
+use libipld::{multihash::Code, cbor::DagCborCodec, ipld, Block, DefaultParams};
 use std::time::Duration;
 use testground::client::Client;
 use tokio::{sync::oneshot, time::Instant};

--- a/test-plans/fetching/Cargo.toml
+++ b/test-plans/fetching/Cargo.toml
@@ -4,12 +4,11 @@ name = "fetching"
 version = "0.1.0"
 
 [dependencies]
-cid = "0.8.6"
 env_logger = "0.9.0"
 if-addrs = "0.7.0"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", branch = "downgrade-cid" }
 fvm_ipld_blockstore = "0.1.1"
-libipld = "0.14.0"
+libipld = { version = "0.14.0", features = ["serde-codec"] }
 futures = "0.3.1"
 fvm_ipld_car = "0.6.0"
 libp2p = { version = "0.50", features = ["websocket", "mplex", "yamux", "tcp", "async-std", "ping", "noise", "dns", "rsa", "macros"]}

--- a/test-plans/fetching/src/lib.rs
+++ b/test-plans/fetching/src/lib.rs
@@ -1,6 +1,5 @@
-use cid::multihash::Code;
 use ipld_traversal::blockstore::Blockstore as GSBlockstore;
-use libipld::{cbor::DagCborCodec, ipld, Block, DefaultParams};
+use libipld::{multihash::Code, cbor::DagCborCodec, ipld, Block, DefaultParams};
 use libp2p_bitswap::BitswapStore;
 use std::time::Duration;
 use testground::client::Client;
@@ -47,11 +46,6 @@ pub async fn run_test(client: &mut Client, node: Node) -> Result<(String, Durati
             .unwrap();
 
         let mut bitswap_store = BitswapStorage(node.store.clone());
-        if bitswap_store.contains(block.cid()).unwrap() {
-            client.record_message("[before] BLOCK CONTAINED");
-        } else {
-            client.record_message("[before] BLOCK NOT CONTAINED");
-        }
         // Remove the block from the store so that it has to be retrieved from
         // the peers for the bitswap get request
         node.store.db.delete(block.cid().to_bytes().as_slice()).unwrap();


### PR DESCRIPTION
## Why
Addresses #239. `libipld` still has to be upgraded to 0.15 for compatibility with `rs-graphsync`.

## What
- Remove `cid` crate dependency and import cid stuff from `libipld` crate to reduce dependency conflicts

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
