### PR TITLE
chore: move kad replication factor to config

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -194,8 +194,7 @@ where
         // setup the kademlia behaviour
         let mut kad = {
             let store = MemoryStore::new(local_peer_id);
-            // todo(botch): move replication factor to config
-            let replication_factor = NonZeroUsize::new(8).unwrap();
+            let replication_factor = NonZeroUsize::new(config.kad_replication_factor).unwrap();
             let mut kad_config = KademliaConfig::default();
             kad_config
                 .set_protocol_names(vec![Cow::from(KAD_PROTOCOL)])

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -40,6 +40,9 @@ pub struct NetworkConfig {
     /// Defaults to devnet tracker.
     #[serde(default = "NetworkConfig::default_tracker")]
     pub tracker: String,
+    /// Determines the number of closest peers to which a record is replicated
+    #[serde(default = "NetworkConfig::default_kad_replication_factor")]
+    pub kad_replication_factor: usize,
 }
 
 impl NetworkConfig {
@@ -82,6 +85,9 @@ impl NetworkConfig {
     fn default_identity() -> String {
         "default".to_string()
     }
+    fn default_kad_replication_factor() -> usize {
+        8
+    }
 }
 
 impl Default for NetworkConfig {
@@ -98,6 +104,7 @@ impl Default for NetworkConfig {
             identity: Self::default_identity(),
             tracker: Self::default_tracker(),
             keystore_path: Self::default_keystore_path(),
+            kad_replication_factor: Self::default_kad_replication_factor(),
         }
     }
 }


### PR DESCRIPTION
## Why
The replication factor was hardcoded in.

## What
- Moves the kad replication factor into `NetworkConfig`.

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
