### PR TITLE
feat(tracker): only provide nodes that registered within 30 days

### DIFF
--- a/crates/ursa-tracker/src/main.rs
+++ b/crates/ursa-tracker/src/main.rs
@@ -8,6 +8,7 @@ use hyper::HeaderMap;
 use rocksdb::{IteratorMode, WriteBatch, DB};
 use serde_json::{json, Value};
 use std::{env, net::SocketAddr, sync::Arc};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -105,12 +106,17 @@ async fn registration_handler(
 
 /// Prometheus HTTP Service Discovery
 async fn http_sd_handler(db: Extension<Arc<DB>>) -> (StatusCode, Json<Value>) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
     let services: Vec<PrometheusDiscoveryChunk> = db
         .iterator(IteratorMode::Start)
         .filter_map(|res| {
             if let Ok((_, v)) = res {
                 let node: Node = serde_json::from_slice(&v).unwrap();
-                if node.telemetry {
+                // only return registrations in the last 1 month
+                if now - node.last_registered < 2629800000 {
                     Some(node.into())
                 } else {
                     None

--- a/crates/ursa-tracker/src/main.rs
+++ b/crates/ursa-tracker/src/main.rs
@@ -7,8 +7,12 @@ use axum::{
 use hyper::HeaderMap;
 use rocksdb::{IteratorMode, WriteBatch, DB};
 use serde_json::{json, Value};
-use std::{env, net::SocketAddr, sync::Arc};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    env,
+    net::SocketAddr,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->

Tracker is returning a ton of stale nodes to prometheus. As a first effort to curate the list of "active" nodes, we should limit to 30 days, so that old nodes/configs eventually don't get scraped

This cuts the scrape target list down from ~1500 targets to ~1100 targets, and I'm sure many more being excluded as time progresses

## Notes

- We could probably use a shorter time period, like 2-3 weeks, but I went with a more generous number to avoid excluding nodes that just don't update/restart often and wouldn't reregister in time

## Checklist

- [n.a] I have made corresponding changes to the tests
- [n.a] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
