### PR TITLE
feat: bootstrap timeout retry logic + new peer log level

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -18,6 +18,7 @@ use db::Store;
 use fvm_ipld_blockstore::Blockstore;
 use graphsync::GraphSync;
 use libipld::{store::StoreParams, Cid};
+use libp2p::kad::{NoKnownPeers, QueryId};
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
     autonat::{Behaviour as Autonat, Config as AutonatConfig},
@@ -249,6 +250,10 @@ where
         self.kad.add_address(peer_id, addr.clone());
         self.request_response.add_address(peer_id, addr.clone());
         self.graphsync.add_address(peer_id, addr);
+    }
+
+    pub fn bootstrap(&mut self) -> Result<QueryId, NoKnownPeers> {
+        self.kad.bootstrap()
     }
 
     pub fn publish(


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->

Some node operators have been reporting random bootstrap timeouts, and metrics show some nodes with low/no peers.

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- adds retry logic for bootstrap timeouts
- gives up after 10 tries
- raise new peer log level for more comfort to node operators that their node is receiving peers correctly

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

I raised the log level for new peers, but it may be preferable to revert that change. If so, we could start directing node runners to use
```
curl localhost:4069/metrics | grep peers 
```
which would return something like 
```
# TYPE swarm_connected_peers gauge
swarm_connected_peers 101
```
as a small healthcheck on the nodes connection status

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
