### PR TITLE
fix(metrics): don't expose unique error labels for swarm connections

### DIFF
--- a/crates/ursa-metrics/src/swarm.rs
+++ b/crates/ursa-metrics/src/swarm.rs
@@ -52,19 +52,13 @@ impl<TBvEv, THandleErr> Recorder for SwarmEvent<TBvEv, THandleErr> {
             SwarmEvent::IncomingConnection { .. } => {
                 increment_counter!("swarm_connections_incoming");
             }
-            SwarmEvent::IncomingConnectionError { error, .. } => {
-                increment_counter!(
-                    "swarm_connections_incoming_error",
-                    vec![Label::new("error", error.to_string()),]
-                );
+            SwarmEvent::IncomingConnectionError { .. } => {
+                increment_counter!("swarm_connections_incoming_error",);
             }
-            SwarmEvent::OutgoingConnectionError { error, peer_id } => {
+            SwarmEvent::OutgoingConnectionError { peer_id, .. } => {
                 increment_counter!(
                     "swarm_outgoing_connection_error",
-                    vec![
-                        Label::new("error", error.to_string()),
-                        PeerStatus::from(peer_id).into()
-                    ]
+                    vec![PeerStatus::from(peer_id).into()]
                 );
             }
             SwarmEvent::BannedPeer { .. } => {


### PR DESCRIPTION
# What

Fixes huge numbers of tsdb series created from using unique error labels from swarm connection metrics. Such large quantities are crippling the prometheus instance causing restart loops

# Why

## Head Stats

Name                   | value
---------------------- | -------
Number of Series	   | 2371423
Number of Chunks	   | 21758610
Number of Label Pairs  | 1286990
Current Min Time	   | 2023-02-02T20:00:00
Current Max Time       | 2023-02-03T19:45:16

## Head Cardinality Stats

### Top 10 label names with value count

Name	     | Count
------------ | -------
error	     | 1280643
request_id   | 3047
id		     | 1331
instance     | 1137
peer	     | 399
geohash	     | 157
__name__     | 103
timezone     | 45
country_code | 36
protocol     | 22

### Top 10 series count by metric names

Name							  | Count
--------------------------------- | -------
swarm_outgoing_connection_error	  | 2265300
swarm_connections_incoming_error  | 12436
kad_routing_updated				  | 11392
identify_supported_protocols	  | 10428
kad_query_result_num_failure	  | 5810
kad_query_result_num_requests	  | 5810
kad_query_result_duration		  | 5810
kad_query_result_num_success	  | 5810
ping_rtt						  | 5789
req_res_request_received		  | 3761

### Top 10 label names with high memory usage

Name	   | Bytes
---------- | ----------
error	   | 4929882516
request	   | 481633
id	       | 69212
instance   | 20892
peer	   | 20748
request_id | 13922
__name__   | 2700
geohash	   | 1099
timezone   | 629
protocol   | 430

### Top 10 series count by label value pairs

Name									 | Count
---------------------------------------- | ------
job=nodes	         					 | 2371369
agent=ursa/0.1.0					     | 2371369
peer_status=known						 | 2265300
__name__=swarm_outgoing_connection_error | 2265300
country_code=DE						     | 1755778
timezone=Europe/Berlin					 | 1755778
geohash=u0xxkv6							 | 429550
geohash=u1hg6hw						     | 341811
geohash=u0yjje5							 | 266505
country_code=FI							 | 169735

## Checklist

- [~] I have made corresponding changes to the tests
- [~] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
