### PR TITLE
feat: add testground to ci [work in progress]

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -1,0 +1,73 @@
+name: testground-ci
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "crates/**"
+      - "test-plans/**"
+      - "Cargo.toml"
+      - ".github/workflows/testground.yml"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "crates/**"
+      - "test-plans/**"
+      - "Cargo.toml"
+      - ".github/workflows/testground.yml"
+
+jobs:
+  tests:
+    name: test plan ${{ matrix.plan }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        plan: ["data-transfer", "fetching"]
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+      - name: Create crates dir
+        run: mkdir -p test-plans/${{ matrix.plan }}/crates
+      - name: Copy ursa Cargo.toml 
+        run: cp Cargo.toml test-plans/${{ matrix.plan }}/crates
+      - name: Copy ursa-network source code into test plan
+        run: cp -r crates/ursa-network test-plans/${{ matrix.plan }}/crates
+      - name: Copy ursa-store source code into test plan
+        run: cp -r crates/ursa-store test-plans/${{ matrix.plan }}/crates
+      - name: Copy ursa-index-provider source code into test plan
+        run: cp -r crates/ursa-index-provider test-plans/${{ matrix.plan }}/crates
+      - name: Copy ursa-metrics source code into test plan
+        run: cp -r crates/ursa-metrics test-plans/${{ matrix.plan }}/crates
+      - name: Use ursa-network from current commit
+        run: |
+            sed -i \
+            's|ursa-network = { git = "https://github.com/fleek-network/ursa" }|ursa-network = { path = "crates/ursa-network" }|g' \
+            test-plans/${{ matrix.plan }}/Cargo.toml
+      - name: Use ursa-store from current commit
+        run: |
+            sed -i \
+            's|ursa-store = { git = "https://github.com/fleek-network/ursa" }|ursa-store = { path = "crates/ursa-store" }|g' \
+            test-plans/${{ matrix.plan }}/Cargo.toml
+      - name: Use ursa-index-provider from current commit
+        run: |
+            sed -i \
+            's|ursa-index-provider = { git = "https://github.com/fleek-network/ursa" }|ursa-index-provider = { path = "crates/ursa-index-provider" }|g' \
+            test-plans/${{ matrix.plan }}/Cargo.toml
+
+      - name: Clone testground
+        run: git clone https://github.com/testground/testground.git
+      - name: Install testground
+        run: cd testground && make install && cd ..
+      - name: Append to path
+        run: echo "$HOME/go/bin" >> $GITHUB_PATH
+      - name: Import test plans
+        run: testground plan import --from ./test-plans/ --name ursa
+      - name: Run test plan 
+        run: testground daemon & sleep 5 && testground run composition -f test-plans/${{ matrix.plan }}/_compositions/rust.toml --wait
+      - name: Kill testground daemon
+        run: kill $!
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # rust
 **/target/
+test-plans/*/crates
 Cargo.lock
 
 # ursa configs and databases

--- a/scripts/run_testground.sh
+++ b/scripts/run_testground.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# import test plans
+if [ ! -d "$HOME/testground/plans/ursa" ]; then
+    testground plan import --from ../test-plans/ --name ursa
+fi
+
+for plan in "$@"
+do
+    mkdir -p ../test-plans/$plan/crates
+    # copy over the current code
+    yes | cp -rf crates/ursa-network test-plans/$plan/crates
+    yes | cp -rf crates/ursa-index-provider test-plans/$plan/crates
+    yes | cp -rf crates/ursa-store test-plans/$plan/crates
+    yes | cp -rf crates/ursa-metrics test-plans/$plan/crates
+    yes | cp -f Cargo.toml test-plans/$plan/crates
+    
+    # overwrite the source in Cargo.toml
+    sed -i \
+    's|ursa-index-provider = { git = "https://github.com/fleek-network/ursa" }|ursa-index-provider = { path = "crates/ursa-index-provider" }|g' \
+    test-plans/$plan/Cargo.toml
+
+    sed -i \
+    's|ursa-network = { git = "https://github.com/fleek-network/ursa" }|ursa-network = { path = "crates/ursa-network" }|g' \
+    test-plans/$plan/Cargo.toml
+
+    sed -i \
+    's|ursa-store = { git = "https://github.com/fleek-network/ursa" }|ursa-store = { path = "crates/ursa-store" }|g' \
+    test-plans/$plan/Cargo.toml
+
+    # run test plan
+    testground daemon & sleep 5 && testground run composition -f test-plans/$plan/_compositions/rust.toml --wait
+
+    # kill daemon running in background
+    kill $!  
+done

--- a/test-plans/data-transfer/Dockerfile
+++ b/test-plans/data-transfer/Dockerfile
@@ -10,10 +10,13 @@ RUN apt-get update && apt-get install -y cmake protobuf-compiler libclang-dev li
 RUN mkdir -p ./plan/src/
 RUN echo "fn main() {}" > ./plan/src/main.rs
 COPY ./plan/Cargo.toml ./plan/
-RUN cd ./plan/  && cargo build --release
+COPY ./plan/crates ./plan/crates
+RUN cd ./plan/ && cargo build --release
 
 COPY . .
 
+RUN ls -l plan
+RUN ls -l plan/crates
 RUN cd ./plan/  \
     && cargo build --release \
     && mv /usr/src/testplan/plan/target/release/data-transfer /usr/local/bin/testplan

--- a/test-plans/fetching/Cargo.toml
+++ b/test-plans/fetching/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 testground = "0.4"
 tokio = { version = "1.23", default-features = false, features = ["sync", "rt-multi-thread", "macros", "net"] }
 db = { package = "forest_db", version = "0.2.0", git = "https://github.com/theBeardA/forest-rocksdb", branch = "chore/upgrade-db", features = ["rocksdb"] }
-ursa-network = { git = "https://github.com/fleek-network/ursa" }
-ursa-store = { git = "https://github.com/fleek-network/ursa" }
-ursa-index-provider = { git = "https://github.com/fleek-network/ursa" }
+ursa-network = { path = "crates/ursa-network" }
+ursa-store = { path = "crates/ursa-store" }
+ursa-index-provider = { path = "crates/ursa-index-provider" }
 rand = "0.8.5"

--- a/test-plans/fetching/Dockerfile
+++ b/test-plans/fetching/Dockerfile
@@ -10,10 +10,13 @@ RUN apt-get update && apt-get install -y cmake protobuf-compiler libclang-dev li
 RUN mkdir -p ./plan/src/
 RUN echo "fn main() {}" > ./plan/src/main.rs
 COPY ./plan/Cargo.toml ./plan/
-RUN cd ./plan/  && cargo build --release
+COPY ./plan/crates ./plan/crates
+RUN cd ./plan/ && cargo build --release
 
 COPY . .
 
+RUN ls -l plan
+RUN ls -l plan/crates
 RUN cd ./plan/  \
     && cargo build --release \
     && mv /usr/src/testplan/plan/target/release/fetching /usr/local/bin/testplan


### PR DESCRIPTION
See #311.
This is a draft PR because it's not working currently. I'm running into https://github.com/testground/testground/issues/1541. Interestingly, this only happens when using Github workflows and never when running the test plans locally. The problem is that the directories for the current run are not created at `/root/.config/testground/data/outputs/local_docker/fetching/<run-id>/<plan>/<index>`. The directory `/root/.config/testground/data/outputs` exists. Manually creating these directories might be a quick fix but won't solve the underlying issue.
I created a discussion in the testground repo for this issue: https://github.com/testground/testground/discussions/1568

Another thing to note:
At the moment, we are pulling the ursa crates from the ursa git repository. This can be seen for example here: https://github.com/fleek-network/ursa/blob/main/test-plans/fetching/Cargo.toml. This is fine but defeats the purpose of running the test plans on every PR. For this, we have to use the code from the current commit. The most straightforward way that I came up with to achieve this is to copy the code from the ursa crates into the test plan directories and then temporarily overwriting the corresponding Cargo.toml.

I added a script `scripts/run_testground.sh` that takes care of this when running testground locally.
