### PR TITLE
refactor(store): remove GraphSyncStorage

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -43,9 +43,9 @@ use libp2p::{
 use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapStore};
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashSet, iter};
-use std::sync::Arc;
 
 use tracing::{info, warn};
 use ursa_metrics::BITSWAP_REGISTRY;

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -40,7 +40,7 @@ use libp2p::{
     swarm::NetworkBehaviour,
     Multiaddr, PeerId,
 };
-use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapStore};
+use libp2p_bitswap::{Bitswap, BitswapConfig};
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::sync::Arc;

--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -48,7 +48,7 @@ use std::{collections::HashSet, iter};
 
 use tracing::{info, warn};
 use ursa_metrics::BITSWAP_REGISTRY;
-use ursa_store::GraphSyncStorage;
+use ursa_store::UrsaStore;
 
 use crate::gossipsub::build_gossipsub;
 use crate::{
@@ -104,7 +104,7 @@ where
     pub(crate) request_response: RequestResponse<UrsaExchangeCodec>,
 
     /// Graphsync for efficiently exchanging data between blocks between peers.
-    pub(crate) graphsync: GraphSync<GraphSyncStorage<S>>,
+    pub(crate) graphsync: GraphSync<UrsaStore<S>>,
 }
 
 impl<P, S> Behaviour<P, S>
@@ -116,7 +116,7 @@ where
         keypair: &Keypair,
         config: &NetworkConfig,
         bitswap_store: B,
-        graphsync_store: GraphSyncStorage<S>,
+        store: UrsaStore<S>,
         relay_client: Option<libp2p::relay::v2::client::Client>,
         peers: &mut HashSet<PeerId>,
     ) -> Self {
@@ -204,7 +204,7 @@ where
         };
 
         // Set up the Graphsync behaviour.
-        let graphsync = GraphSync::new(graphsync_store);
+        let graphsync = GraphSync::new(store);
 
         // init bootstraps
         for addr in config.bootstrap_nodes.iter() {

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -57,7 +57,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 use ursa_metrics::Recorder;
-use ursa_store::{BitswapStorage, GraphSyncStorage, UrsaStore};
+use ursa_store::{BitswapStorage, UrsaStore};
 
 use crate::behaviour::KAD_PROTOCOL;
 use crate::codec::protocol::{RequestType, ResponseType};
@@ -257,14 +257,13 @@ where
         };
 
         let bitswap_store = BitswapStorage(store.clone());
-        let graphsync_store = GraphSyncStorage(store.clone());
         let transport = build_transport(&keypair, config, relay_transport);
         let mut peers = HashSet::new();
         let behaviour = Behaviour::new(
             &keypair,
             config,
             bitswap_store,
-            graphsync_store,
+            store.as_ref().clone(),
             relay_client,
             &mut peers,
         );

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -19,7 +19,7 @@ use futures_util::stream::StreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use graphsync::{GraphSyncEvent, Request};
 use ipld_traversal::{selector::RecursionLimit, Selector};
-use libipld::{Cid, DefaultParams};
+use libipld::{Cid};
 use libp2p::{
     autonat::{Event as AutonatEvent, NatStatus},
     gossipsub::{
@@ -74,11 +74,11 @@ pub const MESSAGE_PROTOCOL: &[u8] = b"/ursa/message/0.0.1";
 
 type BlockOneShotSender<T> = oneshot::Sender<Result<T, Error>>;
 type SwarmEventType<S> = SwarmEvent<
-<Behaviour<DefaultParams, S> as NetworkBehaviour>::OutEvent,
+<Behaviour<S> as NetworkBehaviour>::OutEvent,
 <
     <
         <
-            Behaviour<DefaultParams, S> as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler
+            Behaviour<S> as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler
         >::Handler as ConnectionHandler
     >::Error
 >;
@@ -195,7 +195,7 @@ where
     /// Store.
     pub store: Arc<UrsaStore<S>>,
     /// The main libp2p swarm emitting events.
-    swarm: Swarm<Behaviour<DefaultParams, S>>,
+    swarm: Swarm<Behaviour<S>>,
     /// Handles outbound messages to peers.
     command_sender: Sender<NetworkCommand>,
     /// Handles inbound messages from peers.
@@ -256,13 +256,11 @@ where
             (None, None)
         };
 
-        let bitswap_store = BitswapStorage(store.clone());
         let transport = build_transport(&keypair, config, relay_transport);
         let mut peers = HashSet::new();
         let behaviour = Behaviour::new(
             &keypair,
             config,
-            bitswap_store,
             store.as_ref().clone(),
             relay_client,
             &mut peers,

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -19,7 +19,7 @@ use futures_util::stream::StreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use graphsync::{GraphSyncEvent, Request};
 use ipld_traversal::{selector::RecursionLimit, Selector};
-use libipld::{Cid};
+use libipld::Cid;
 use libp2p::{
     autonat::{Event as AutonatEvent, NatStatus},
     gossipsub::{

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -57,7 +57,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 use ursa_metrics::Recorder;
-use ursa_store::{BitswapStorage, UrsaStore};
+use ursa_store::UrsaStore;
 
 use crate::behaviour::KAD_PROTOCOL;
 use crate::codec::protocol::{RequestType, ResponseType};

--- a/crates/ursa-store/src/store.rs
+++ b/crates/ursa-store/src/store.rs
@@ -15,17 +15,9 @@ use libipld::{
 use libp2p_bitswap::BitswapStore;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UrsaStore<S> {
     pub db: Arc<S>,
-}
-
-impl<S> Clone for UrsaStore<S> {
-    fn clone(&self) -> Self {
-        Self {
-            db: self.db.clone(),
-        }
-    }
 }
 
 impl<S> UrsaStore<S>


### PR DESCRIPTION
## Why

The explicit `GraphSyncStore` struct is not needed, as the required trait for graphsync can be instead implemented directly on UrsaStore itself 

## What

- remove graphsyncstorage and use ursastore directly
- construct bitswapStorage from behaviour from a single ursastore param

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
