### PR TITLE
chore: remove port from domain

### DIFF
--- a/crates/ursa-gateway/src/config.rs
+++ b/crates/ursa-gateway/src/config.rs
@@ -103,7 +103,7 @@ impl Default for GatewayConfig {
                 stream_buf: 2_000_000, // 2MB
             },
             indexer: IndexerConfig {
-                cid_url: "https://cid.contact/cid".into(),
+                cid_url: "https://dev.cid.contact/cid".into(),
             },
         }
     }

--- a/crates/ursa-index-provider/src/advertisement.rs
+++ b/crates/ursa-index-provider/src/advertisement.rs
@@ -48,6 +48,7 @@ pub struct Advertisement {
     /// IsRm specifies whether this advertisement represents the content are no longer retrievable fom the provider.
     pub IsRm: bool,
 }
+
 impl Advertisement {
     pub fn new(
         context_id: Vec<u8>,

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -165,7 +165,7 @@ where
         if let Some(head_cid) = *self.head.read().unwrap() {
             let message = Message {
                 Cid: head_cid,
-                Addrs: vec![multiaddr],
+                Addresses: vec![multiaddr],
                 ExtraData: *b"",
             };
 
@@ -181,9 +181,10 @@ where
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Message {
     pub Cid: Cid,
-    pub Addrs: Vec<Multiaddr>,
+    pub Addresses: Vec<Multiaddr>,
     pub ExtraData: [u8; 0],
 }
+
 impl Cbor for Message {
     fn marshal_cbor(&self) -> Result<Vec<u8>, fvm_ipld_encoding::Error> {
         const MESSAGE_BUFFER_LENGTH: [u8; 1] = [131];
@@ -192,7 +193,7 @@ impl Cbor for Message {
         let _encoded_cid = self.Cid.encode(DagCborCodec, &mut bytes);
 
         let encoded_addrs =
-            fvm_ipld_encoding::to_vec(&self.Addrs).expect("addresses serialization cannot fail");
+            fvm_ipld_encoding::to_vec(&self.Addresses).expect("addresses serialization cannot fail");
         bytes
             .write_all(&encoded_addrs)
             .expect("writing encoded address to bytes should not fail");

--- a/crates/ursa-rpc-service/src/config.rs
+++ b/crates/ursa-rpc-service/src/config.rs
@@ -18,7 +18,7 @@ pub struct ServerConfig {
 
 impl ServerConfig {
     fn default_domain() -> Multiaddr {
-        "/ip4/127.0.0.1/tcp/4069".parse().unwrap()
+        "/ip4/127.0.0.1".parse().unwrap()
     }
     fn default_port() -> u16 {
         4069

--- a/crates/ursa-rpc-service/src/server.rs
+++ b/crates/ursa-rpc-service/src/server.rs
@@ -8,7 +8,7 @@ use crate::{
     api::NodeNetworkInterface,
     config::ServerConfig,
     http,
-    rpc::{routes, RpcServer},
+    rpc::{self, RpcServer},
     service::MultiplexService,
 };
 use tracing::info;
@@ -56,7 +56,7 @@ where
 
     pub fn rpc_app(&self) -> Router {
         Router::new()
-            .merge(routes::network::init())
+            .merge(rpc::routes::network::init())
             .layer(Extension(self.rpc_server.clone()))
     }
 


### PR DESCRIPTION
## Why
- nodes expose 443 and not 4069

## What

- Change domain default
- We are not golang so using full words
- change gateway default indexer URL

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
