### PR TITLE
feat: save public address instead of requesting from autonat each time

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -260,10 +260,6 @@ where
         self.gossipsub.publish(topic, data)
     }
 
-    pub fn public_address(&self) -> Option<&Multiaddr> {
-        self.autonat.as_ref().and_then(|a| a.public_address())
-    }
-
     pub fn subscribe(&mut self, topic: &Topic) -> Result<bool, SubscriptionError> {
         self.gossipsub.subscribe(topic)
     }

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -421,7 +421,7 @@ where
                     if self.swarm.behaviour().relay_client.is_enabled() {
                         if let Some(addr) = self.bootstraps.choose(&mut rand::thread_rng()) {
                             let circuit_addr = addr.clone().with(Protocol::P2pCircuit);
-                            error!(
+                            warn!(
                                 "Private NAT detected. Nodes should be publically accessable on 4890(udp) and 6009(tcp), as well as standard http(80) and https(443)! Falling back temporarily to public relay address on bootstrap node {}",
                                 circuit_addr
                                     .clone()


### PR DESCRIPTION
## Why

Allows for us to use the last known public address. Sometimes, the NAT status will fall back to private due to network idle, and the address is unknown

## What

- increase log level for private nat status, and expand the error message to hint that the user's setup is wrong and should be fixed
- save last received public address

## Checklist

- [na] I have made corresponding changes to the tests
- [na] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
