### PR TITLE
chore: change default gateway indexer url

### DIFF
--- a/crates/ursa-gateway/src/config.rs
+++ b/crates/ursa-gateway/src/config.rs
@@ -109,7 +109,7 @@ impl Default for GatewayConfig {
                 cache_time_to_live: 5 * 60 * 1000, //  5 mins.
             },
             indexer: IndexerConfig {
-                cid_url: "https://cid.contact/cid".into(),
+                cid_url: "https://dev.cid.contact/cid".into(),
             },
         }
     }


### PR DESCRIPTION
## Why

- right now we use the dev cid contact so we should use the dev one
- 
## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
