### PR TITLE
refactor(config): use serde default on each struct directly

### DIFF
--- a/crates/ursa-application/src/config.rs
+++ b/crates/ursa-application/src/config.rs
@@ -1,22 +1,16 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ApplicationConfig {
     ///The address the application is listening on. defaults to "0.0.0.0:8003"
-    #[serde(default = "ApplicationConfig::default_domain")]
     pub domain: String,
-}
-
-impl ApplicationConfig {
-    fn default_domain() -> String {
-        "0.0.0.0:8003".into()
-    }
 }
 
 impl Default for ApplicationConfig {
     fn default() -> Self {
         Self {
-            domain: Self::default_domain(),
+            domain: "0.0.0.0:8003".into(),
         }
     }
 }

--- a/crates/ursa-index-provider/src/config.rs
+++ b/crates/ursa-index-provider/src/config.rs
@@ -2,34 +2,19 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ProviderConfig {
-    /// ! Deprecated ! Moved to `ursa-rpc-service` config.
-    /// Left here for backwards compatability; so that configs can be migrated
-    #[serde(default)]
-    pub domain: Option<String>,
     /// indexer url to point to, eg. https://dev.cid.contact
-    #[serde(default = "ProviderConfig::default_indexer_url")]
     pub indexer_url: String,
     /// database_path for index provider db
-    #[serde(default = "ProviderConfig::default_database_path")]
     pub database_path: PathBuf,
-}
-
-impl ProviderConfig {
-    fn default_database_path() -> PathBuf {
-        "~/.ursa/data/index_provider_db".into()
-    }
-    fn default_indexer_url() -> String {
-        "https://dev.cid.contact".to_string()
-    }
 }
 
 impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
-            domain: None,
-            indexer_url: Self::default_indexer_url(),
-            database_path: Self::default_database_path(),
+            indexer_url: "https://dev.cid.contact".to_string(),
+            database_path: "~/.ursa/data/index_provider_db".into(),
         }
     }
 }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -4,114 +4,60 @@ use std::path::PathBuf;
 
 /// Ursa Configuration
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(default)]
 pub struct NetworkConfig {
     /// Optional mdns local discovery.
-    #[serde(default = "NetworkConfig::default_mdns")]
     pub mdns: bool,
     /// Optional Provide a relay server for other peers to listen on.
-    #[serde(default = "NetworkConfig::default_relay_server")]
     pub relay_server: bool,
     /// Optional autonat. This is used to determine if we are behind a NAT and need to use a relay.
-    #[serde(default = "NetworkConfig::default_autonat")]
     pub autonat: bool,
     /// Optional Enable listening on a relay server if not publicly available. Requires autonat.
     /// Connections will attempt to upgrade using dcutr.
-    #[serde(default = "NetworkConfig::default_relay_client")]
     pub relay_client: bool,
     /// set true if it is a bootstrap node. default = false
-    #[serde(default = "NetworkConfig::default_bootstrapper")]
     pub bootstrapper: bool,
     /// Swarm listening Address.
-    #[serde(default = "NetworkConfig::default_swarm_addrs")]
     pub swarm_addrs: Vec<Multiaddr>,
     /// Bootstrap nodes.
-    #[serde(default = "NetworkConfig::default_bootstrap_nodes")]
     pub bootstrap_nodes: Vec<Multiaddr>,
     /// Database path.
-    #[serde(default = "NetworkConfig::default_database_path")]
     pub database_path: PathBuf,
     /// user identity name
-    #[serde(default = "NetworkConfig::default_identity")]
     pub identity: String,
     /// Keystore path. Defaults to ~/.ursa/keystore
-    #[serde(default = "NetworkConfig::default_keystore_path")]
     pub keystore_path: PathBuf,
     /// Temporary HTTP tracker url. This is used for pre-consensus node registrations.
     /// Defaults to devnet tracker.
-    #[serde(default = "NetworkConfig::default_tracker")]
     pub tracker: String,
     /// Determines the number of closest peers to which a record is replicated
-    #[serde(default = "NetworkConfig::default_kad_replication_factor")]
     pub kad_replication_factor: usize,
     /// Interval to run random kademlia walks to refresh the routing table. Defaults to 5 minutes
-    #[serde(default = "NetworkConfig::default_kad_walk_interval")]
     pub kad_walk_interval: u64,
-}
-
-impl NetworkConfig {
-    fn default_mdns() -> bool {
-        false
-    }
-    fn default_autonat() -> bool {
-        true
-    }
-    fn default_relay_client() -> bool {
-        true
-    }
-    fn default_relay_server() -> bool {
-        true
-    }
-    fn default_bootstrapper() -> bool {
-        false
-    }
-    fn default_tracker() -> String {
-        "https://tracker.ursa.earth/register".to_string()
-    }
-    fn default_bootstrap_nodes() -> Vec<Multiaddr> {
-        vec![
-            "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p".parse().unwrap(),
-            "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM".parse().unwrap(),
-        ]
-    }
-    fn default_swarm_addrs() -> Vec<Multiaddr> {
-        vec![
-            "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
-            "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap(),
-        ]
-    }
-    fn default_database_path() -> PathBuf {
-        "~/.ursa/data/ursa_db".into()
-    }
-    fn default_keystore_path() -> PathBuf {
-        "~/.ursa/keystore".into()
-    }
-    fn default_identity() -> String {
-        "default".to_string()
-    }
-    fn default_kad_replication_factor() -> usize {
-        8
-    }
-    fn default_kad_walk_interval() -> u64 {
-        300
-    }
 }
 
 impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
-            mdns: Self::default_mdns(),
-            autonat: Self::default_autonat(),
-            relay_client: Self::default_relay_client(),
-            relay_server: Self::default_relay_server(),
-            bootstrapper: Self::default_bootstrapper(),
-            bootstrap_nodes: Self::default_bootstrap_nodes(),
-            swarm_addrs: Self::default_swarm_addrs(),
-            database_path: Self::default_database_path(),
-            identity: Self::default_identity(),
-            tracker: Self::default_tracker(),
-            keystore_path: Self::default_keystore_path(),
-            kad_replication_factor: Self::default_kad_replication_factor(),
-            kad_walk_interval: Self::default_kad_walk_interval(),
+            mdns: false,
+            autonat: true,
+            relay_client: true,
+            relay_server: true,
+            bootstrapper: true,
+            bootstrap_nodes: vec![
+                "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p".parse().unwrap(),
+                "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM".parse().unwrap(),
+            ],
+            swarm_addrs: vec![
+                "/ip4/0.0.0.0/tcp/6009".parse().unwrap(),
+                "/ip4/0.0.0.0/udp/4890/quic-v1".parse().unwrap(),
+            ],
+            database_path: "~/.ursa/data/ursa_db".into(),
+            keystore_path: "~/.ursa/keystore".into(),
+            identity: "default".into(), 
+            tracker: "https://tracker.ursa.earth/register".into(),
+            kad_replication_factor: 8, 
+            kad_walk_interval: 300,
         }
     }
 }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -56,7 +56,7 @@ impl Default for NetworkConfig {
             keystore_path: "~/.ursa/keystore".into(),
             identity: "default".into(), 
             tracker: "https://tracker.ursa.earth/register".into(),
-            kad_replication_factor: 8, 
+            kad_replication_factor: 8,
             kad_walk_interval: 300,
         }
     }

--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -43,7 +43,7 @@ impl Default for NetworkConfig {
             autonat: true,
             relay_client: true,
             relay_server: true,
-            bootstrapper: true,
+            bootstrapper: false,
             bootstrap_nodes: vec![
                 "/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p".parse().unwrap(),
                 "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM".parse().unwrap(),

--- a/crates/ursa-rpc-service/src/config.rs
+++ b/crates/ursa-rpc-service/src/config.rs
@@ -2,62 +2,43 @@ use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(default)]
 pub struct ServerConfig {
-    /// Public IP address of the node, eg. `/ip4/127.0.0.1`
-    #[serde(default = "ServerConfig::default_addresses")]
+    /// Public multiaddresses of the node,
+    /// eg. `/dns/node.user.domain/tcp/4069` or `/ip4/1.2.3.4/tcp/4069`
     pub addresses: Vec<Multiaddr>,
     /// Port to listen on
-    #[serde(default = "ServerConfig::default_port")]
     pub port: u16,
     /// Address to bind to
-    #[serde(default = "ServerConfig::default_addr")]
     pub addr: String,
-    #[serde(default)]
+    /// Origin fallback configuration
     pub origin: OriginConfig,
-}
-
-impl ServerConfig {
-    fn default_addresses() -> Vec<Multiaddr> {
-        vec!["/ip4/127.0.0.1/tcp/4069".parse().unwrap()]
-    }
-    fn default_port() -> u16 {
-        4069
-    }
-    fn default_addr() -> String {
-        "0.0.0.0".to_string()
-    }
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
-            addresses: Self::default_addresses(),
-            port: Self::default_port(),
-            addr: Self::default_addr(),
+            addresses: vec!["/ip4/127.0.0.1/tcp/4069".parse().unwrap()],
+            port: 4069,
+            addr: "0.0.0.0".to_string(),
             origin: Default::default(),
         }
     }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(default)]
 pub struct OriginConfig {
     /// Ipfs gateway url
-    #[serde(default = "OriginConfig::default_ipfs_gateway")]
     pub ipfs_gateway: String,
     /// Intended for testing purposes
     pub use_https: Option<bool>,
 }
 
-impl OriginConfig {
-    pub fn default_ipfs_gateway() -> String {
-        "ipfs.io".to_string()
-    }
-}
-
 impl Default for OriginConfig {
     fn default() -> Self {
         Self {
-            ipfs_gateway: Self::default_ipfs_gateway(),
+            ipfs_gateway: "ipfs.io".to_string(),
             use_https: None,
         }
     }

--- a/crates/ursa/src/config.rs
+++ b/crates/ursa/src/config.rs
@@ -16,14 +16,11 @@ use ursa_rpc_service::config::ServerConfig;
 pub const DEFAULT_CONFIG_PATH_STR: &str = ".ursa/config.toml";
 
 #[derive(Default, Serialize, Deserialize, Debug)]
+#[serde(default)]
 pub struct UrsaConfig {
-    #[serde(default)]
     pub network_config: NetworkConfig,
-    #[serde(default)]
     pub provider_config: ProviderConfig,
-    #[serde(default)]
     pub server_config: ServerConfig,
-    #[serde(default)]
     pub consensus_config: ConsensusConfig,
 }
 


### PR DESCRIPTION
## Why

simplifies default value logic for configs. Functionality should be the exact same

## Checklist

- [x] ~~I have made corresponding changes to the tests~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have run the app using my feature and ensured that no functionality is broken
