### PR TITLE
fix: invalid addresses are being published

### DIFF
--- a/crates/ursa-index-provider/src/engine.rs
+++ b/crates/ursa-index-provider/src/engine.rs
@@ -163,7 +163,7 @@ where
                         } else {
                             match self
                                 .provider
-                                .create_announce_message(peer_id, &mut self.addresses)
+                                .create_announce_message(peer_id, self.addresses.clone())
                             {
                                 Ok(announce_message) => {
                                     if let Err(e) = self

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -106,7 +106,7 @@ pub trait ProviderInterface: Sync + Send + 'static {
     fn create_announce_message(
         &mut self,
         peer_id: PeerId,
-        addresses: &mut Vec<Multiaddr>,
+        addresses: Vec<Multiaddr>,
     ) -> Result<Vec<u8>>;
 }
 
@@ -164,7 +164,7 @@ where
     fn create_announce_message(
         &mut self,
         peer_id: PeerId,
-        addresses: &mut Vec<Multiaddr>,
+        mut addresses: Vec<Multiaddr>,
     ) -> Result<Vec<u8>> {
         let multiaddrs = addresses
             .iter_mut()


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->
Invalid addresses are being published because we're mutating the address in the provider engine instead of working with a fresh copy every time we handle it.

```
INFO ursa_index_provider::provider: Announcing the advertisement with the message Message { Cid: Cid(bafy2bzaceaxrvnmnbeelm2vmjlbs7rbin4p4ovfekgezr63kqerixll7jgney), Addrs: ["/ip4/64.225.0.251/tcp/4069/http/p2p/12D3KooWQUYSiMjHVVd6BC2U2dsiaM8YhnfszAF9ruwyp99kym6a/http/p2p/12D3KooWQUYSiMjHVVd6BC2U2dsiaM8YhnfszAF9ruwyp99kym6a"], ExtraData: [] }
at crates/ursa-index-provider/src/provider.rs:185
```



## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Clone and pass address.

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
