### PR TITLE
fix the make install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ version:
 run: version
 	cargo run --bin cli
 
-install: version
-	cargo install --locked --path crates/ursa --force
+install: version build
+	cp ./target/release/ursa ~/.cargo/bin/
 
 build: version
 	cargo build --release --bin ursa

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ run: version
 	cargo run --bin cli
 
 install: version build
+	mkdir -p ~/.cargo/bin/
 	cp ./target/release/ursa ~/.cargo/bin/
 
 build: version


### PR DESCRIPTION
## Why

supposedly, `cargo install` does not support workspaces properly, so at this point using it leads to different builds from `cargo build` and also different dependency trees, which means our current make file is broken.

Fixes # (issue)

## What

- Remove the use of `cargo install`.
- Replace it with `mkdir -p` and `cp`.

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
