### PR TITLE
update to the latest workspace-hack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ axum-tracing-opentelemetry = "0.8.2"
 axum-prometheus = "0.3.0"
 
 [patch.'https://github.com/MystenLabs/sui.git']
-workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.git", rev = "d9224476db385706fd0822c0d6738bdb503542d3"}
+workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.git", rev = "c07eb1e343a455d57a5481b50eada03c62b4f2c6"}
 
 [profile.release]
 # 2 full, 0 nothing, 1 good enough.

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ version:
 run: version
 	cargo run --bin cli
 
-install: version build
-	mkdir -p ~/.cargo/bin/
-	cp ./target/release/ursa ~/.cargo/bin/
+install: version
+	cargo install --locked --path crates/ursa
 
 build: version
 	cargo build --release --bin ursa


### PR DESCRIPTION
## Why

to make `cargo install` work again.

Fixes # (issue)

## What

i added strum to our workspace-hack crate and it fixed it.

https://github.com/fleek-network/empty-workspace-hack/commit/c07eb1e343a455d57a5481b50eada03c62b4f2c6

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
