### PR TITLE
chore: 🤖 publish port to host

### DIFF
--- a/docker/full-node/docker-compose.yml
+++ b/docker/full-node/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       dockerfile: Dockerfile
     restart: on-failure
     ports:
+      - "4069:4069"
       - "6009:6009"
     expose:
       # 4069 TCP, used for HTTP RPC, REST, and metrics


### PR DESCRIPTION
## Why

Port 4069 is used internally only, so been decided not to expose and related past PR closed. Although there are responses to users in the discord channel, which hint them to test port 4069, which would not be possible from the host as port 4069 is not exposed to it. By having this one merged in, test port 4069 is also valid for Docker Stack not just native. Otherwise, the user has to execute the health check inside the container or strictly via the reverse proxy. Examples:  https://discord.com/channels/965698989464887386/1047823701292355634/1074515851732070410 where user shares https://discord.com/channels/965698989464887386/1047823701292355634/1074532128328527934

Fixes # (issue)

## What

- Recall exposing 4069 to host for docker users

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
