### PR TITLE
fix(full-node): add a 72hr max retention time for tsdb (prom)

### DIFF
--- a/docker/full-node/docker-compose.yml
+++ b/docker/full-node/docker-compose.yml
@@ -62,7 +62,10 @@ services:
       - "9090"
     volumes:
       - ./data/prom:/etc/prometheus
-    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+    command: 
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=72h'
     depends_on:
       - ursa
       - node-exporter


### PR DESCRIPTION
## Why

Prometheus is taking up a large amount of space due to uncapped retention time. Sets a generous limit at 72h

## Notes

We could do less, say 24hrs instead

## Checklist

- [x] ~~I have made corresponding changes to the tests~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have run the app using my feature and ensured that no functionality is broken~~
