### PR TITLE
fix: use libp2p@0.50.1 git patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,10 @@ axum-prometheus = "0.3.0"
 [patch.'https://github.com/MystenLabs/sui.git']
 workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.git", rev = "c07eb1e343a455d57a5481b50eada03c62b4f2c6"}
 
+[patch.'crates-io']
+# fix libp2p 0.50.0's prerelease deps (quic, webrtc, tls)
+libp2p = { git = "https://github.com/ozwaldorf/rust-libp2p", rev = "be344c0abfa5c4eaa90d769eeece5bf875b86a57" }
+
 [profile.release]
 # 2 full, 0 nothing, 1 good enough.
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ jsonrpc-v2 = "0.11.0"
 lazy_static = "1.4"
 libipld = { version = "0.14.0", features = ["serde-codec"] }
 libipld-core = "0.14.0"
-libp2p = { version = "0.50.0", default-features = false }
+libp2p = { version = "0.50.1", default-features = false }
 libp2p-bitswap = "0.25.0"
 libipld-cbor = "0.14.0"
 libp2p-swarm = "0.41.1"
@@ -106,7 +106,7 @@ axum-prometheus = "0.3.0"
 workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.git", rev = "c07eb1e343a455d57a5481b50eada03c62b4f2c6"}
 
 [patch.'crates-io']
-# fix libp2p 0.50.0's prerelease deps (quic, webrtc, tls)
+# fix libp2p 0.50.1, the crate release is messed up (libp2p-quic)
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d8de86e991ad540e6f69ca417c27f7407198944f" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.
 
 [patch.'crates-io']
 # fix libp2p 0.50.0's prerelease deps (quic, webrtc, tls)
-libp2p = { git = "https://github.com/ozwaldorf/rust-libp2p", rev = "be344c0abfa5c4eaa90d769eeece5bf875b86a57" }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d8de86e991ad540e6f69ca417c27f7407198944f" }
 
 [profile.release]
 # 2 full, 0 nothing, 1 good enough.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ axum-prometheus = "0.3.0"
 workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.git", rev = "c07eb1e343a455d57a5481b50eada03c62b4f2c6"}
 
 [patch.'crates-io']
-# fix libp2p 0.50.1, the crate release is messed up (libp2p-quic)
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d8de86e991ad540e6f69ca417c27f7407198944f" }
 
 [profile.release]


### PR DESCRIPTION
## Why

Fixes fresh build issues by patching libp2p 0.50 to use the versions it requires to work instead of the latest prereleases. Fixes our CI pipeline as well

## What

- patch libp2p dep with the latest 0.50.1 git version to fix libp2p-quic

## Checklist

- [x] ~~I have made corresponding changes to the tests~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have run the app using my feature and ensured that no functionality is broken
