### PR TITLE
feat(node): send cache requests to peers in replication set

### DIFF
--- a/crates/ursa-network/src/behaviour.rs
+++ b/crates/ursa-network/src/behaviour.rs
@@ -43,15 +43,16 @@ use libp2p::{
 };
 use libp2p_bitswap::{Bitswap, BitswapConfig};
 use std::borrow::Cow;
+use std::iter;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashSet, iter};
 
 use tracing::{info, warn};
 use ursa_metrics::BITSWAP_REGISTRY;
 use ursa_store::{BitswapStorage, UrsaStore};
 
+use crate::connection::Manager;
 use crate::gossipsub::build_gossipsub;
 use crate::{
     codec::protocol::{UrsaExchangeCodec, UrsaProtocol},
@@ -118,7 +119,7 @@ where
         config: &NetworkConfig,
         store: UrsaStore<S>,
         relay_client: Option<libp2p::relay::v2::client::Client>,
-        peers: &mut HashSet<PeerId>,
+        peers: &mut Manager,
     ) -> Self {
         let local_public_key = keypair.public();
         let local_peer_id = PeerId::from(local_public_key.clone());

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -22,9 +22,10 @@ impl Manager {
     }
 
     pub fn handle_rtt_received(&mut self, rtt: Duration, peer: PeerId) {
+        debug!("Received {rtt:?} rtt for {peer}");
         if rtt > MAX_RTT {
             self.replication_set.remove(&peer);
-            debug!("{peer} was not added because of high rrt {rtt:?}");
+            debug!("{peer} was not added because of high rrt");
             return;
         }
         if !self.connected_peers.contains(&peer) {

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -3,7 +3,13 @@ use std::collections::HashMap;
 use std::{collections::HashSet, time::Duration};
 use tracing::debug;
 
+#[cfg(test)]
+const REPLICATION_MAX_SIZE: usize = usize::MAX;
+#[cfg(not(test))]
 const REPLICATION_MAX_SIZE: usize = 2;
+#[cfg(test)]
+const MAX_RTT: Duration = Duration::MAX;
+#[cfg(not(test))]
 const MAX_RTT: Duration = Duration::from_millis(15);
 
 #[derive(Default)]

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -31,7 +31,8 @@ impl Manager {
             debug!("{peer} was not added because we don't have a connection for it");
             return;
         }
-        if self.replication_set.len() > MESH_MAX_SIZE && !self.replication_set.contains_key(&peer) {
+        if self.replication_set.len() >= MESH_MAX_SIZE && !self.replication_set.contains_key(&peer)
+        {
             if let Some(peer_with_max_rtt) = self
                 .replication_set
                 .iter()

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -72,9 +72,6 @@ impl Manager {
     }
 
     pub fn replication_set(&self) -> Vec<PeerId> {
-        self.replication_set
-            .iter()
-            .map(|(peer, _)| peer.clone())
-            .collect()
+        self.replication_set.clone().into_keys().collect()
     }
 }

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -21,7 +21,6 @@ impl Manager {
 
     pub fn handle_rtt_received(&mut self, rtt: Duration, peer: PeerId) {
         if rtt > MAX_RTT {
-            // Remove if peer was in the mesh.
             self.mesh_peers.remove(&peer);
             debug!("{peer} was not added because of high rrt {rtt:?}");
             return;

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -1,0 +1,69 @@
+use libp2p::PeerId;
+use std::collections::HashMap;
+use std::{collections::HashSet, time::Duration};
+use tracing::debug;
+
+const MESH_MAX_SIZE: usize = 3;
+const MAX_RTT: Duration = Duration::from_millis(15);
+
+pub struct Manager {
+    connected_peers: HashSet<PeerId>,
+    mesh_peers: HashMap<PeerId, Duration>,
+}
+
+impl Manager {
+    pub fn handle_rtt_received(&mut self, rtt: Duration, peer: PeerId) {
+        if rtt > MAX_RTT {
+            debug!("{peer} was not added because of high rrt {rtt:?}");
+            return;
+        }
+        if !self.connected_peers.contains(&peer) {
+            debug!("{peer} was not added because we don't have a connection for it");
+            return;
+        }
+        if self.mesh_peers.len() > MESH_MAX_SIZE {
+            if let Some(peer_with_max_rtt) = self
+                .mesh_peers
+                .iter()
+                .max_by_key(|(_, duration)| duration)
+                .map(|(peer, _)| peer)
+            {
+                debug!("Removing {} from mesh", peer_with_max_rtt);
+                self.mesh_peers.remove(peer_with_max_rtt);
+                debug!("Adding {peer} to mesh");
+                self.mesh_peers.insert(peer, rtt);
+            }
+        } else {
+            debug!("Adding {peer} to mesh");
+            self.mesh_peers.insert(peer, rtt);
+        }
+    }
+
+    pub fn insert(&mut self, peer: PeerId) -> bool {
+        self.connected_peers.insert(peer)
+    }
+
+    pub fn contains(&self, peer: &PeerId) -> bool {
+        self.connected_peers.contains(peer)
+    }
+
+    pub fn ref_peers(&self) -> &HashSet<PeerId> {
+        &self.connected_peers
+    }
+
+    pub fn peers(&self) -> HashSet<PeerId> {
+        self.connected_peers.clone()
+    }
+
+    pub fn remove(&mut self, peer: &PeerId) -> bool {
+        self.mesh_peers.remove(peer);
+        self.connected_peers.remove(peer)
+    }
+
+    pub fn mesh_peers(&self) -> Vec<PeerId> {
+        self.mesh_peers
+            .iter()
+            .map(|(peer, _)| peer.clone())
+            .collect()
+    }
+}

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -7,7 +7,9 @@ const MESH_MAX_SIZE: usize = 3;
 const MAX_RTT: Duration = Duration::from_millis(15);
 
 pub struct Manager {
+    /// Connected peers.
     connected_peers: HashSet<PeerId>,
+    /// Set of peers to use in content replication.
     replication_set: HashMap<PeerId, Duration>,
 }
 
@@ -69,7 +71,6 @@ impl Manager {
         self.connected_peers.remove(peer)
     }
 
-    /// Set of peers to use in content replication.
     pub fn replication_set(&self) -> Vec<PeerId> {
         self.replication_set
             .iter()

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 const REPLICATION_MAX_SIZE: usize = 3;
 const MAX_RTT: Duration = Duration::from_millis(15);
 
+#[derive(Default)]
 pub struct Manager {
     /// Connected peers.
     connected_peers: HashSet<PeerId>,
@@ -15,10 +16,7 @@ pub struct Manager {
 
 impl Manager {
     pub fn new() -> Self {
-        Self {
-            connected_peers: HashSet::new(),
-            replication_set: HashMap::new(),
-        }
+        Self::default()
     }
 
     pub fn handle_rtt_received(&mut self, rtt: Duration, peer: PeerId) {
@@ -38,9 +36,9 @@ impl Manager {
             if let Some(peer_with_max_rtt) = self
                 .replication_set
                 .iter()
-                .max_by_key(|(_, duration)| duration.clone())
+                .max_by_key(|(_, duration)| **duration)
                 .filter(|(_, duration)| duration > &&rtt)
-                .map(|(peer, _)| peer.clone())
+                .map(|(peer, _)| *peer)
             {
                 debug!("Removing {} from mesh", peer_with_max_rtt);
                 self.replication_set.remove(&peer_with_max_rtt);

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::{collections::HashSet, time::Duration};
 use tracing::debug;
 
-const MESH_MAX_SIZE: usize = 3;
+const REPLICATION_MAX_SIZE: usize = 3;
 const MAX_RTT: Duration = Duration::from_millis(15);
 
 pub struct Manager {
@@ -31,7 +31,8 @@ impl Manager {
             debug!("{peer} was not added because we don't have a connection for it");
             return;
         }
-        if self.replication_set.len() >= MESH_MAX_SIZE && !self.replication_set.contains_key(&peer)
+        if self.replication_set.len() >= REPLICATION_MAX_SIZE
+            && !self.replication_set.contains_key(&peer)
         {
             if let Some(peer_with_max_rtt) = self
                 .replication_set

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::{collections::HashSet, time::Duration};
 use tracing::debug;
 
-const REPLICATION_MAX_SIZE: usize = 3;
+const REPLICATION_MAX_SIZE: usize = 2;
 const MAX_RTT: Duration = Duration::from_millis(15);
 
 #[derive(Default)]

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -12,6 +12,13 @@ pub struct Manager {
 }
 
 impl Manager {
+    pub fn new() -> Self {
+        Self {
+            connected_peers: HashSet::new(),
+            mesh_peers: HashMap::new(),
+        }
+    }
+
     pub fn handle_rtt_received(&mut self, rtt: Duration, peer: PeerId) {
         if rtt > MAX_RTT {
             debug!("{peer} was not added because of high rrt {rtt:?}");

--- a/crates/ursa-network/src/connection.rs
+++ b/crates/ursa-network/src/connection.rs
@@ -35,12 +35,12 @@ impl Manager {
             if let Some(peer_with_max_rtt) = self
                 .replication_set
                 .iter()
-                .max_by_key(|(_, duration)| duration)
+                .max_by_key(|(_, duration)| duration.clone())
                 .filter(|(_, duration)| duration > &&rtt)
-                .map(|(peer, _)| peer)
+                .map(|(peer, _)| peer.clone())
             {
                 debug!("Removing {} from mesh", peer_with_max_rtt);
-                self.replication_set.remove(peer_with_max_rtt);
+                self.replication_set.remove(&peer_with_max_rtt);
                 debug!("Adding {peer} to mesh");
                 self.replication_set.insert(peer, rtt);
             }

--- a/crates/ursa-network/src/lib.rs
+++ b/crates/ursa-network/src/lib.rs
@@ -1,6 +1,7 @@
 mod behaviour;
 mod codec;
 pub mod config;
+mod connection;
 mod gossipsub;
 pub mod service;
 mod transport;

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -788,7 +788,7 @@ where
             NetworkCommand::Put { cid, sender } => {
                 // replicate content
                 let swarm = self.swarm.behaviour_mut();
-                for peer in self.peers.mesh_peers() {
+                for peer in self.peers.replication_set() {
                     info!("[NetworkCommand::Put] - sending cache request to peer {peer} for {cid}");
                     swarm
                         .request_response

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -347,6 +347,7 @@ where
                     rtt.as_millis(),
                     ping_event.peer.to_base58(),
                 );
+                self.peers.handle_rtt_received(rtt, ping_event.peer);
             }
             Ok(libp2p::ping::Success::Pong) => {
                 trace!(

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -61,6 +61,7 @@ use ursa_store::UrsaStore;
 
 use crate::behaviour::KAD_PROTOCOL;
 use crate::codec::protocol::{RequestType, ResponseType};
+use crate::connection::Manager;
 use crate::transport::build_transport;
 use crate::utils::cache_summary::CacheSummary;
 use crate::{
@@ -213,7 +214,7 @@ where
     /// Pending responses.
     pending_responses: HashMap<RequestId, oneshot::Sender<Result<UrsaExchangeResponse>>>,
     /// Connected peers.
-    peers: HashSet<PeerId>,
+    peers: Manager,
     /// Bootstrap multiaddrs.
     bootstraps: Vec<Multiaddr>,
     /// Summarizes the cached content.
@@ -259,7 +260,7 @@ where
         };
 
         let transport = build_transport(&keypair, config, relay_transport);
-        let mut peers = HashSet::new();
+        let mut peers = Manager::new();
         let behaviour = Behaviour::new(
             &keypair,
             config,
@@ -741,7 +742,7 @@ where
             NetworkCommand::GetBitswap { cid, sender } => {
                 info!("Getting cid {cid} via bitswap");
 
-                let peers = self.peers.clone();
+                let peers = self.peers.peers();
 
                 if peers.is_empty() {
                     error!(
@@ -786,16 +787,16 @@ where
             NetworkCommand::Put { cid, sender } => {
                 // replicate content
                 let swarm = self.swarm.behaviour_mut();
-                for peer in &self.peers {
+                for peer in self.peers.mesh_peers() {
                     info!("[NetworkCommand::Put] - sending cache request to peer {peer} for {cid}");
                     swarm
                         .request_response
-                        .send_request(peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
+                        .send_request(&peer, UrsaExchangeRequest(RequestType::CacheRequest(cid)));
                 }
                 // update cache summary and share it with the connected peers
                 self.cached_content.insert(&cid.to_bytes());
                 let swarm = self.swarm.behaviour_mut();
-                for peer in &self.peers {
+                for peer in self.peers.ref_peers() {
                     let request = UrsaExchangeRequest(RequestType::StoreSummary(Box::new(
                         self.cached_content.clone(),
                     )));
@@ -808,7 +809,7 @@ where
             }
             NetworkCommand::GetPeers { sender } => {
                 sender
-                    .send(self.peers.clone())
+                    .send(self.peers.peers())
                     .map_err(|_| anyhow!("Failed to get Libp2p peers!"))?;
             }
             NetworkCommand::GetListenerAddresses { sender } => {

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -213,7 +213,7 @@ where
     _pending_requests: HashMap<RequestId, ResponseChannel<UrsaExchangeResponse>>,
     /// Pending responses.
     pending_responses: HashMap<RequestId, oneshot::Sender<Result<UrsaExchangeResponse>>>,
-    /// Connected peers.
+    /// Manages set of connected peers.
     peers: Manager,
     /// Bootstrap multiaddrs.
     bootstraps: Vec<Multiaddr>,

--- a/crates/ursa-network/src/tests/service_tests.rs
+++ b/crates/ursa-network/src/tests/service_tests.rs
@@ -505,6 +505,20 @@ async fn test_put_command() -> Result<()> {
             }
         }
     }
+
+    loop {
+        if let SwarmEvent::Behaviour(BehaviourEvent::Ping(libp2p::ping::Event {
+            result: Ok(libp2p::ping::Success::Pong),
+            peer,
+        })) = node_2.swarm.select_next_some().await
+        {
+            if peer == peer_id_1 {
+                info!("Sent a pong to {peer_id_1:?}");
+                break;
+            }
+        }
+    }
+
     tokio::task::spawn(async move { node_2.start().await.unwrap() });
 
     // Send node 1 a PUT command.


### PR DESCRIPTION
## Why

Fixes https://github.com/fleek-network/ursa/issues/357

Too many cache requests are being sent.

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Add a manager to handle access to list of connected peers and a separate subset of that list (replication set).
- When we receive rtt from a PING, we pass the event to manager to update the replication set.
- Our assumption of rtt is that if it's high (higher than some threshold), then the peer must be far away.  High rtt could also indicate network congestion. Thus, peers will not be added to the replication set if rtt is high because we don't want to use this set to replicate content to peers who are far away and/or make network congestion worse. There are other factors that affect rtt but for the problem at hand #357, these assumptions seem reasonable. Open to suggestions of course.


## Checklist

- [x] I have made corresponding changes to the tests
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have run the app using my feature and ensured that no functionality is broken
