### PR TITLE
feat: limit number of stored cache summaries

### DIFF
--- a/crates/ursa-network/src/config.rs
+++ b/crates/ursa-network/src/config.rs
@@ -46,6 +46,9 @@ pub struct NetworkConfig {
     /// Interval to run random kademlia walks to refresh the routing table. Defaults to 5 minutes
     #[serde(default = "NetworkConfig::default_kad_walk_interval")]
     pub kad_walk_interval: u64,
+    /// Maximum number of cache summaries from other peers to store.
+    #[serde(default = "NetworkConfig::default_max_cache_summaries")]
+    pub max_cache_summaries: usize,
 }
 
 impl NetworkConfig {
@@ -94,6 +97,9 @@ impl NetworkConfig {
     fn default_kad_walk_interval() -> u64 {
         300
     }
+    fn default_max_cache_summaries() -> usize {
+        10
+    }
 }
 
 impl Default for NetworkConfig {
@@ -112,6 +118,7 @@ impl Default for NetworkConfig {
             keystore_path: Self::default_keystore_path(),
             kad_replication_factor: Self::default_kad_replication_factor(),
             kad_walk_interval: Self::default_kad_walk_interval(),
+            max_cache_summaries: Self::default_max_cache_summaries(),
         }
     }
 }

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -614,7 +614,7 @@ where
                         RequestType::StoreSummary(cache_summary) => {
                             if self.peer_cached_content.len() == self.max_cache_summaries {
                                 let key_to_remove =
-                                    *self.peer_cached_content.iter().next().unwrap().0;
+                                    *self.peer_cached_content.keys().next().unwrap();
                                 self.peer_cached_content.remove(&key_to_remove).unwrap();
                             }
                             self.peer_cached_content.insert(peer, *cache_summary);

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -223,6 +223,8 @@ where
     peer_cached_content: HashMap<PeerId, CacheSummary>,
     /// Interval for random Kademlia walks.
     kad_walk_interval: u64,
+    /// Maximum number of cache summaries from other peers to store.
+    max_cache_summaries: usize,
     /// Public address reported from autonat
     pub public_addr: Option<Multiaddr>,
 }
@@ -318,6 +320,7 @@ where
             cached_content: CacheSummary::default(),
             peer_cached_content: HashMap::default(),
             kad_walk_interval: config.kad_walk_interval,
+            max_cache_summaries: config.max_cache_summaries,
             public_addr: None,
         })
     }
@@ -609,6 +612,11 @@ where
                             }
                         }
                         RequestType::StoreSummary(cache_summary) => {
+                            if self.peer_cached_content.len() == self.max_cache_summaries {
+                                let key_to_remove =
+                                    *self.peer_cached_content.iter().next().unwrap().0;
+                                self.peer_cached_content.remove(&key_to_remove).unwrap();
+                            }
                             self.peer_cached_content.insert(peer, *cache_summary);
                             if self
                                 .swarm


### PR DESCRIPTION
## Why
Nodes store cache summaries they receive from their peers in a map. However, the size of the map is not bounded at the moment. This can lead to too much memory usage. This PR will restrict the map size to a configurable parameter.

## What
- Adds config parameter for the maximum number of cache summaries to store.
- If the map exceeds this number, an arbitrary cache summary is removed from the map.

## Checklist

- [x] I have made corresponding changes to the tests
- [N/A] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
