### PR TITLE
chore: 🤖 curl is required by health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
+    curl \
     && apt-get clean \
     && apt-get purge -y \
     && rm -rf /var/lib/apt/lists*


### PR DESCRIPTION
## Why

Curl is required by health check

Fixes # (issue)

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Add dependency in apt-get command

