### PR TITLE
feat(gateway): ignore distance computation when public IP isn't provided

### DIFF
--- a/crates/ursa-gateway/src/resolver/mod.rs
+++ b/crates/ursa-gateway/src/resolver/mod.rs
@@ -37,7 +37,7 @@ pub struct Resolver {
     client: Client,
     cache: Cache<String, Addresses>,
     maxminddb: Arc<Reader<Vec<u8>>>,
-    location: Location,
+    location: GatewayLocation,
 }
 
 impl Resolver {
@@ -48,10 +48,15 @@ impl Resolver {
         maxminddb: Arc<Reader<Vec<u8>>>,
         addr: IpAddr,
     ) -> Result<Self, Error> {
-        let city = maxminddb
-            .lookup::<City>(addr)
-            .map_err(|e| anyhow!(e.to_string()))?;
-        let location = get_location(city)?;
+        let location = if addr.is_loopback() {
+            GatewayLocation::Private
+        } else {
+            let city = maxminddb
+                .lookup::<City>(addr)
+                .map_err(|e| anyhow!(e.to_string()))?;
+            GatewayLocation::Public(get_location(city)?)
+        };
+
         Ok(Self {
             indexer_cid_url,
             client,
@@ -90,25 +95,35 @@ impl Resolver {
                 }
                 let host = host.unwrap();
                 let port = port.unwrap();
-                let city = self
-                    .maxminddb
-                    .lookup::<City>(host)
-                    .map_err(|e| {
-                        debug!(
-                            "Failed to get location for ip {} with error {}",
-                            host,
-                            e.to_string()
-                        )
-                    })
-                    .ok();
-                let location = get_location(city?)
-                    .map_err(|e| debug!("Failed to get location for city with ip {host} {:?}", e))
-                    .ok()?;
-                let distance = self.location.haversine_distance_to(&location).meters();
-                if !distance.is_finite() {
-                    debug!("Skipping {host} because distance could not be computed");
-                    return None;
-                }
+                let distance = match self.location {
+                    GatewayLocation::Private => 0f64,
+                    GatewayLocation::Public(gateway_location) => {
+                        let city = self
+                            .maxminddb
+                            .lookup::<City>(host)
+                            .map_err(|e| {
+                                debug!(
+                                    "Failed to get location for ip {} with error {}",
+                                    host,
+                                    e.to_string()
+                                )
+                            })
+                            .ok();
+                        let provider_location = get_location(city?)
+                            .map_err(|e| {
+                                debug!("Failed to get location for city with ip {host} {:?}", e)
+                            })
+                            .ok()?;
+                        let distance = gateway_location
+                            .haversine_distance_to(&provider_location)
+                            .meters();
+                        if !distance.is_finite() {
+                            debug!("Skipping {host} because distance could not be computed");
+                            return None;
+                        }
+                        distance
+                    }
+                };
                 debug!("{host} is {distance:?} meters from host");
                 Some((
                     OrderedFloat(distance),
@@ -278,6 +293,12 @@ impl Resolver {
         self.cache.invalidate(cid);
         Err(Error::Internal("Failed to get data".to_string()))
     }
+}
+
+#[derive(Clone)]
+pub enum GatewayLocation {
+    Private,
+    Public(Location),
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->

Atm you can't run the gateway locally without specifying some public IP and sometimes you may want to run the whole flow locally (indexer, node, gateway).

## What

<!-- Please include a bulleted list of what the pull request is changing --->

Distance computation is ignored when public IP isn't provided.

## Checklist

- [ ] ~I have made corresponding changes to the tests~
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have run the app using my feature and ensured that no functionality is broken
