### PR TITLE
fix: limit jobs on CI build to prevent OoM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,8 +74,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo test --workspace --all-features
-      - run: cargo test --workspace --no-default-features
+      - run: cargo test --jobs 1 --workspace --all-features
+      - run: cargo test --jobs 1 --workspace --no-default-features
 
   coverage:
     name: Tests coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,8 +74,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo test --jobs 1 --workspace --all-features
-      - run: cargo test --jobs 1 --workspace --no-default-features
+      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --no-default-features
 
   coverage:
     name: Tests coverage
@@ -121,8 +121,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo test --workspace --all-features
-      - run: cargo test --workspace --no-default-features
+      - run: cargo test --jobs 1 --workspace --all-features
+      - run: cargo test --jobs 1 --workspace --no-default-features
 
       - name: Setup grcov
         id: coverage


### PR DESCRIPTION
## Why

Failing on github CI with exit code 143 or 137 when compiling from out of memory. This should prevent this by limiting cargo to 1 job at a time while compiling(currently defaults to 2 on github)

## Checklist

- [x] I have made corresponding changes to the tests
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
