### PR TITLE
fix: don't add ipld car headers for /metrics

### DIFF
--- a/docker/full-node/data/nginx/app.conf
+++ b/docker/full-node/data/nginx/app.conf
@@ -36,6 +36,10 @@ server {
 
       proxy_pass http://ursa:4069;
     }
+
+    location /metrics {
+      proxy_pass http://ursa:4069;
+    }
 }
 
 server {


### PR DESCRIPTION
## Why

`/metrics` should not include ipld car or cache control headers from nginx

## What

- assign `/metrics` it's own location in nginx app.conf

## Notes

May need to also match these changes on the assisted installer since it creates http.conf and https.conf

## Checklist

- [x] ~~I have made corresponding changes to the tests~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have run the app using my feature and ensured that no functionality is broken
