### PR TITLE
fix: fvm_ipld_encoding, forest_db, and ethers dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ctrlc = "3.2.4"
 db = { package = "forest_db", git = "https://github.com/ChainSafe/forest", rev = "3e682310482718182cb2495fbaec5e575e5884e5", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "16f9fab75cb43e2d9e4c2b74b68afde7577f0e2f" }
 integer-encoding = "3.0.4"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", rev = "b8728c7ad02aa42cc11954192e95875f14fc6380" }
 fastmurmur3 = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ctrlc = "3.2.4"
 db = { package = "forest_db", git = "https://github.com/ChainSafe/forest", rev = "3e682310482718182cb2495fbaec5e575e5884e5", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
-ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "16f9fab75cb43e2d9e4c2b74b68afde7577f0e2f" }
+ethers = "1.0.2"
 integer-encoding = "3.0.4"
 ipld_traversal = { git = "https://github.com/kckeiks/rs-graphsync.git", rev = "b8728c7ad02aa42cc11954192e95875f14fc6380" }
 fastmurmur3 = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bytes = "1.3.0"
 clap = { version = "4.0.29", features = ["derive"] }
 console-subscriber = "0.1.8"
 ctrlc = "3.2.4"
-db = { package = "forest_db", git = "https://github.com/ChainSafe/forest", features = ["rocksdb"] }
+db = { package = "forest_db", git = "https://github.com/ChainSafe/forest", rev = "3e682310482718182cb2495fbaec5e575e5884e5", features = ["rocksdb"] }
 dirs = "4"
 dotenv = "0.15.0"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
@@ -49,7 +49,7 @@ futures = "0.3.25"
 futures-util = "0.3.25"
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_car = "0.6"
-fvm_ipld_encoding = "=0.3.2"
+fvm_ipld_encoding = "0.3.3"
 geoutils = "0.5"
 graphsync = { git = "https://github.com/kckeiks/rs-graphsync.git", rev = "b8728c7ad02aa42cc11954192e95875f14fc6380" }
 hyper = { version = "0.14.23", features = ["full"] }

--- a/crates/ursa-application/Cargo.toml
+++ b/crates/ursa-application/Cargo.toml
@@ -19,9 +19,9 @@ toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-error.workspace = true
+ethers.workspace = true
 
 abci-rs = { version = "0.11.3", features = ["async-api"] }
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
 revm = { version = "3.0.0", features = [
     "serde",
 ] }

--- a/crates/ursa-index-provider/src/provider.rs
+++ b/crates/ursa-index-provider/src/provider.rs
@@ -9,6 +9,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use fvm_ipld_blockstore::Blockstore;
+#[allow(deprecated)]
 use fvm_ipld_encoding::Cbor;
 use libipld::{codec::Encode, multihash::Code, Cid};
 use libipld_cbor::DagCborCodec;
@@ -183,6 +184,7 @@ where
             };
 
             info!("Announcing the advertisement with the message {message:?}");
+            #[allow(deprecated)]
             Ok(message.marshal_cbor().unwrap())
         } else {
             Err(anyhow!("No head found for announcement!"))
@@ -198,6 +200,7 @@ pub struct Message {
     pub ExtraData: [u8; 0],
 }
 
+#[allow(deprecated)]
 impl Cbor for Message {
     fn marshal_cbor(&self) -> Result<Vec<u8>, fvm_ipld_encoding::Error> {
         const MESSAGE_BUFFER_LENGTH: [u8; 1] = [131];


### PR DESCRIPTION
## Why

Because we want ursa to compile!

There are 2 things wrong and one potential issue:
- The current build issue with selecting a version for fvm_ipld_encoding
- The latest forest_db commit breaks our dependence on the `Store` trait's `delete` fn and its implementation for rocksdb. We're getting this breaking change because the git dependency is unpinned to a revision and they removed the fn (ChainSafe/forest#2638)
- Noticed that `ethers-rs` was unpinned, and a breaking change there could cause more issues, and also that ursa-app is not using the workspace dep

## What

- bump fvm_ipld_encoding to 0.3.3
- replace depreciated Cbor impl with Message::to_vec impl
- pin forest_db to a commit with delete still in the `Store` trait and implemented for RocksDB
- use crate release `1.0.2` for ethers-rs
- ursa-app uses workspace ethers version

## Notes

We can update to the new garbage collection method from forest_db in a future PR

## Checklist

- [x] ~~I have made corresponding changes to the tests~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have run the app using my feature and ensured that no functionality is broken
