### PR TITLE
feat: latency measurements

### DIFF
--- a/crates/ursa-network/src/measurements/bandwidth.rs
+++ b/crates/ursa-network/src/measurements/bandwidth.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+pub type Bytes = u128;
+pub type BytesPerSecond = f64;
+pub type RequestId = String;
+
+#[derive(Clone)]
+pub struct Bandwidth {
+    requests: HashMap<RequestId, Request>,
+    sum: BytesPerSecond,
+    count: u64,
+}
+
+impl Bandwidth {
+    pub fn new() -> Self {
+        Self {
+            requests: HashMap::new(),
+            sum: 0.0,
+            count: 0,
+        }
+    }
+
+    pub fn register_request(&mut self, request_id: RequestId, size: Bytes) {
+        self.requests.insert(request_id, Request::new(size));
+    }
+
+    pub fn register_response(&mut self, request_id: RequestId, size: Bytes) {
+        if let Some(request) = self.requests.remove(&request_id) {
+            let total_size = request.size + size;
+            let duration = request.duration().as_secs();
+            if duration > 0 {
+                self.sum += (total_size as f64) / (duration as f64);
+                self.count += 1;
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn get_estimate(&self) -> Option<BytesPerSecond> {
+        if self.count > 0 {
+            Some(self.sum / (self.count as f64))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Request {
+    instant: Instant,
+    size: Bytes,
+}
+
+impl Request {
+    fn new(size: Bytes) -> Self {
+        Self {
+            instant: Instant::now(),
+            size,
+        }
+    }
+
+    fn duration(&self) -> Duration {
+        self.instant.elapsed()
+    }
+}

--- a/crates/ursa-network/src/measurements/latency.rs
+++ b/crates/ursa-network/src/measurements/latency.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+pub type Milliseconds = f64;
+
+#[derive(Clone)]
+pub struct Latency {
+    sum: Milliseconds,
+    count: u64,
+}
+
+impl Latency {
+    pub fn new() -> Self {
+        Self { sum: 0.0, count: 0 }
+    }
+
+    pub fn register_rtt(&mut self, rtt: Duration) {
+        let rtt_millis = rtt.as_millis() as f64;
+        if rtt_millis > 0.0 {
+            self.sum += rtt_millis / 2.0;
+            self.count += 1;
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn get_estimate(&self) -> Option<Milliseconds> {
+        if self.count > 0 {
+            Some(self.sum / (self.count as f64))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -355,6 +355,7 @@ where
                     ping_event.peer.to_base58(),
                 );
                 self.peers.handle_rtt_received(rtt, ping_event.peer);
+                self.measurement_manager.register_rtt(ping_event.peer, rtt);
             }
             Ok(libp2p::ping::Success::Pong) => {
                 trace!(


### PR DESCRIPTION
## Why
We need measurements for the metrics that will be used for the reputation system, see https://github.com/fleek-network/ursa/issues/452. This PR addresses latency measurements.

## What
- Extended `MeasurementManager` so that we can register RTTs for each peer.
- Latency estimates will be computed from RTTs, assuming a symmetric latency between peers (see diagram below).

## Notes
![latency_estimate](https://user-images.githubusercontent.com/25928722/228853331-7b8ca137-67fd-4db2-8a17-e453d2ee3d62.png)

* For the diagram above, the latency will be estimated as follows:
`latency = (t4 - t1) / 2`
* We have to make the assumption that `t3 - t2` is relatively small.


## Checklist

- [x] I have made corresponding changes to the tests
- [N/A] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
