### PR TITLE
feat(pod): basic ufdp delivery decryption exchange

### DIFF
--- a/crates/ursa-pod/README.md
+++ b/crates/ursa-pod/README.md
@@ -1,8 +1,8 @@
 # Ursa Proof of Delivery
 
-## Example
+Implementation for the Ursa Fair Delivery Protocol, used to collect and batch proofs of delivery for verified blake3 streams.
 
-There is a simple tcp client and server example
+## Example
 
 1. Run the server
 

--- a/crates/ursa-pod/examples/client.rs
+++ b/crates/ursa-pod/examples/client.rs
@@ -6,6 +6,8 @@ use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 use ursa_pod::{client::UfdpClient, codec::UrsaCodecError};
 
+const SERVER_ADDRESS: &str = "127.0.0.1:8080";
+const PUB_KEY: [u8; 48] = [2u8; 48];
 const CID: [u8; 32] = [1u8; 32];
 
 #[tokio::main]
@@ -15,8 +17,9 @@ async fn main() -> Result<(), UrsaCodecError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    let stream = TcpStream::connect("127.0.0.1:8080").await?;
-    let mut client = UfdpClient::new(stream).await?;
+    let stream = TcpStream::connect(SERVER_ADDRESS).await?;
+    let mut client = UfdpClient::new(stream, PUB_KEY, None).await?;
+
     let res = client.request(CID).await?;
     let mut reader = StreamReader::new(res);
 

--- a/crates/ursa-pod/examples/server.rs
+++ b/crates/ursa-pod/examples/server.rs
@@ -12,19 +12,23 @@ use ursa_pod::{
 struct DummyBackend {}
 
 impl Backend for DummyBackend {
-    fn raw_content(&self, _cid: Blake3Cid) -> BytesMut {
-        BytesMut::from("hello world!")
+    fn raw_content(&self, _cid: Blake3Cid) -> (BytesMut, u64) {
+        let content = BytesMut::from("hello world!");
+        let request_id = 0;
+        (content, request_id)
+    }
+
+    fn decryption_key(&self, _request_id: u64) -> (ursa_pod::types::Secp256k1AffinePoint, u64) {
+        let key = [1; 33];
+        let key_id = 0;
+        (key, key_id)
     }
 
     fn get_balance(&self, _pubkey: Secp256k1PublicKey) -> u128 {
-        10
+        9001
     }
 
-    fn save_tx(
-        &self,
-        _pubkey: Secp256k1PublicKey,
-        _acknowledgment: BlsSignature,
-    ) -> Result<(), String> {
+    fn save_batch(&self, _batch: BlsSignature) -> Result<(), String> {
         Ok(())
     }
 }

--- a/crates/ursa-pod/src/client.rs
+++ b/crates/ursa-pod/src/client.rs
@@ -8,11 +8,13 @@ use tracing::{debug, error};
 
 use crate::{
     codec::{
-        consts::{MAX_BLOCK_SIZE, MAX_CHUNK_SIZE, MAX_PROOF_SIZE},
+        consts::{MAX_BLOCK_SIZE, MAX_PROOF_SIZE},
         UrsaCodec, UrsaCodecError, UrsaFrame,
     },
     types::{Blake3Cid, BlsPublicKey},
 };
+
+const IO_CHUNK_SIZE: usize = 16 * 1024;
 
 #[derive(Clone, Copy, Debug)]
 pub enum UfdpResponseState {
@@ -103,7 +105,7 @@ where
                     self.client
                         .transport
                         .codec_mut()
-                        .read_buffer(proof_len, MAX_CHUNK_SIZE);
+                        .read_buffer(proof_len, IO_CHUNK_SIZE);
                     self.state = UfdpResponseState::ReadingProof;
                 }
                 (UfdpResponseState::ReadingProof, Some(Ok(UrsaFrame::Buffer(bytes)))) => {
@@ -113,7 +115,7 @@ where
                         self.client
                             .transport
                             .codec_mut()
-                            .read_buffer(block_len, MAX_CHUNK_SIZE);
+                            .read_buffer(block_len, IO_CHUNK_SIZE);
                         self.state = UfdpResponseState::ReadingContent
                     }
                 }

--- a/crates/ursa-pod/src/codec.rs
+++ b/crates/ursa-pod/src/codec.rs
@@ -16,6 +16,12 @@ pub mod consts {
     pub const MAX_FRAME_SIZE: usize = 1024;
     /// Maximum lanes a client can use at one time
     pub const MAX_LANES: u8 = 24;
+    /// Maximum bytes a proof can be
+    pub const MAX_PROOF_SIZE: usize = 16 * 1024;
+    /// Maximum bytes a block can be
+    pub const MAX_BLOCK_SIZE: usize = 256 * 1024;
+    /// Maximum bytes a chunk of a block can be
+    pub const MAX_CHUNK_SIZE: usize = 16 * 1024;
 
     /// The bit flag on any frame tag sent from the node to the client.
     pub const IS_RES_FLAG: u8 = 0b10000000;
@@ -150,7 +156,7 @@ pub enum UrsaFrame {
     HandshakeRequest {
         version: u8,
         supported_compression_bitmap: u8,
-        lane: u8,
+        lane: Option<u8>,
         pubkey: BlsPublicKey,
     },
     /// Node response to confirm a UFDP connection.
@@ -330,7 +336,7 @@ impl Encoder<UrsaFrame> for UrsaCodec {
                 buf.put_slice(&NETWORK);
                 buf.put_u8(version);
                 buf.put_u8(supported_compression_bitmap);
-                buf.put_u8(lane);
+                buf.put_u8(lane.unwrap_or(0xFF));
                 buf.put_slice(&pubkey);
             }
             UrsaFrame::HandshakeResponse {
@@ -436,7 +442,10 @@ impl Decoder for UrsaCodec {
 
                 let version = buf[5];
                 let supported_compression_bitmap = buf[6];
-                let lane = buf[7];
+                let lane = match buf[7] {
+                    0xFF => None,
+                    v => Some(v),
+                };
                 let pubkey = *array_ref!(buf, 8, 48);
 
                 Ok(Some(UrsaFrame::HandshakeRequest {
@@ -579,7 +588,7 @@ mod tests {
             UrsaFrame::HandshakeRequest {
                 version: 0,
                 supported_compression_bitmap: 0,
-                lane: 0xFF,
+                lane: None,
                 pubkey: [1u8; 48],
             }
         )

--- a/crates/ursa-pod/src/codec.rs
+++ b/crates/ursa-pod/src/codec.rs
@@ -24,8 +24,6 @@ pub mod consts {
     pub const MAX_PROOF_SIZE: usize = 47 * 32 + 6;
     /// Maximum bytes a block can be
     pub const MAX_BLOCK_SIZE: usize = 256 * 1024;
-    /// Maximum bytes a chunk of a block can be
-    pub const MAX_CHUNK_SIZE: usize = 16 * 1024;
 
     /// The bit flag on any frame tag sent from the node to the client.
     pub const IS_RES_FLAG: u8 = 0b10000000;

--- a/crates/ursa-pod/src/codec.rs
+++ b/crates/ursa-pod/src/codec.rs
@@ -16,8 +16,12 @@ pub mod consts {
     pub const MAX_FRAME_SIZE: usize = 1024;
     /// Maximum lanes a client can use at one time
     pub const MAX_LANES: u8 = 24;
-    /// Maximum bytes a proof can be
-    pub const MAX_PROOF_SIZE: usize = 16 * 1024;
+    /// Maximum bytes a proof can be. The maximum theoretical file we support is
+    /// `2^64` bytes, given we transfer data as blocks of 256KiB (`2^18` bytes) the
+    /// maximum number of chunks is `2^46`. So the maximum height of the hash tree
+    /// will be 47. So we will have maximum of 47 hashes (hence `47 * 32`) and one byte
+    /// per each 8 hash (`ceil(47 / 8) = 6`).
+    pub const MAX_PROOF_SIZE: usize = 47 * 32 + 6;
     /// Maximum bytes a block can be
     pub const MAX_BLOCK_SIZE: usize = 256 * 1024;
     /// Maximum bytes a chunk of a block can be

--- a/crates/ursa-pod/src/server.rs
+++ b/crates/ursa-pod/src/server.rs
@@ -3,27 +3,30 @@ use futures::SinkExt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::{
-    codec::{UrsaCodec, UrsaCodecError, UrsaFrame},
-    types::{Blake3Cid, BlsSignature, Secp256k1PublicKey},
+    codec::{
+        consts::{MAX_BLOCK_SIZE, MAX_CHUNK_SIZE},
+        UrsaCodec, UrsaCodecError, UrsaFrame,
+    },
+    types::{Blake3Cid, BlsSignature, Secp256k1AffinePoint, Secp256k1PublicKey},
 };
 
 /// Backend trait used by [`UfdpServer`] to access external data
 pub trait Backend: Copy + Send + Sync + 'static {
-    /// Get some raw content for a given cid
-    fn raw_content(&self, cid: Blake3Cid) -> BytesMut;
+    /// Get some raw content for a given cid.
+    /// Returns some raw bytes, and a request id to get the decryption_key
+    fn raw_content(&self, cid: Blake3Cid) -> (BytesMut, u64);
 
-    /// Get a users balance
+    /// Get a decryption_key for a block, includes a block request id
+    fn decryption_key(&self, request_id: u64) -> (Secp256k1AffinePoint, u64);
+
+    /// Get a clients current balance.
     fn get_balance(&self, pubkey: Secp256k1PublicKey) -> u128;
 
-    /// Save a transaction to be batched and submitted
-    fn save_tx(
-        &self,
-        pubkey: Secp256k1PublicKey,
-        acknowledgment: BlsSignature,
-    ) -> Result<(), String>;
+    /// Save a batch of transactions to be submitted to consensus.
+    fn save_batch(&self, batch: BlsSignature) -> Result<(), String>;
 }
 
 /// UFDP Server. Handles any stream of data supporting [`AsyncWrite`] + [`AsyncRead`]
@@ -50,12 +53,17 @@ where
 
             match transport.next().await.expect("handshake request") {
                 Ok(UrsaFrame::HandshakeRequest { lane, .. }) => {
-                    info!("Handshake received, sending response");
+                    debug!("Handshake received, sending response");
+                    let lane = lane.unwrap_or({
+                        // todo: lane management
+                        0
+                    });
+
                     transport
                         .send(UrsaFrame::HandshakeResponse {
                             pubkey: [2; 33],
                             epoch_nonce: 1000,
-                            lane: if lane == 0xFF { 0 } else { lane },
+                            lane,
                             last: None,
                         })
                         .await
@@ -68,36 +76,73 @@ where
                 debug!("Received frame: {request:?}");
                 match request {
                     Ok(UrsaFrame::ContentRequest { hash }) => {
-                        info!("Content request received, sending response");
-                        let block = backend.raw_content(hash);
-                        let proof = BytesMut::from(b"dummy_proof".as_slice());
+                        debug!("Content request received");
+                        let (mut content, request_id) = backend.raw_content(hash);
+                        debug!("Sending content ({} bytes)", content.len());
+                        while !content.is_empty() {
+                            let block_len = content.len().min(MAX_BLOCK_SIZE);
+                            let mut block = content.split_to(block_len);
 
-                        transport
-                            .send(UrsaFrame::ContentResponse {
-                                compression: 0,
-                                proof_len: proof.len() as u64,
-                                block_len: block.len() as u64,
-                                signature: [1u8; 64],
-                            })
-                            .await
-                            .expect("content response");
+                            let (decryption_key, _) = backend.decryption_key(request_id);
 
-                        transport
-                            .send(UrsaFrame::Buffer(proof))
-                            .await
-                            .expect("content data");
+                            // todo: proof encoding
+                            let proof = BytesMut::from(b"dummy_proof".as_slice());
+                            let proof_len = proof.len() as u64;
 
-                        transport
-                            .send(UrsaFrame::Buffer(block))
-                            .await
-                            .expect("content data");
+                            debug!("Sending content response frame");
+                            transport
+                                .send(UrsaFrame::ContentResponse {
+                                    compression: 0,
+                                    proof_len,
+                                    block_len: block_len as u64,
+                                    signature: [1u8; 64],
+                                })
+                                .await
+                                .expect("send content response");
 
+                            debug!("Sending proof ({proof_len} bytes)");
+                            transport
+                                .send(UrsaFrame::Buffer(proof))
+                                .await
+                                .expect("send proof data");
+
+                            let mut current_chunk = 0;
+                            while !block.is_empty() {
+                                let chunk_len = block.len().min(MAX_CHUNK_SIZE);
+                                debug!("Sending chunk #{current_chunk}");
+                                transport
+                                    .send(UrsaFrame::Buffer(block.split_to(chunk_len)))
+                                    .await
+                                    .expect("send content data");
+                                current_chunk += 1;
+                            }
+
+                            // wait for delivery acknowledgment
+                            match transport.next().await {
+                                Some(Ok(UrsaFrame::DecryptionKeyRequest { .. })) => {
+                                    debug!("Delivery acknowledgment received");
+                                    // todo: transaction manager (batch and store tx)
+                                }
+                                Some(Ok(f)) => error!("Unexpected frame {f:?}"),
+                                Some(Err(e)) => error!("Codec error: {e:?}"),
+                                None => error!("Connection closed"),
+                            }
+
+                            debug!("Sending decryption key");
+                            // send decryption key
+                            transport
+                                .send(UrsaFrame::DecryptionKeyResponse { decryption_key })
+                                .await
+                                .expect("send decryption key");
+                        }
+
+                        debug!("Sending EOR");
                         transport
                             .send(UrsaFrame::EndOfRequestSignal)
                             .await
-                            .expect("EOR");
+                            .expect("send EOR");
                     }
-                    Ok(_) => unimplemented!(),
+                    Ok(f) => error!("Unexpected frame: {f:?}"),
                     Err(e) => {
                         error!("{e:?}");
                         break;


### PR DESCRIPTION
## Why

Server should expect delivery acknowledgment from clients, and send the decryption key back for each block. it should also start splitting content into 256kb blocks

## What

- add implementation for decryption key exchange for client and server
- refactor server implementation
  - split content into 256kb blocks
  - chunk blocks into 16kb chunks
  - Backend trait now has a method to get a new decryption key
- add some debug logs (can be switched to trace instead)

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
