### PR TITLE
feat: uptime measurements

### DIFF
--- a/crates/ursa-network/src/measurements/bandwidth.rs
+++ b/crates/ursa-network/src/measurements/bandwidth.rs
@@ -1,9 +1,6 @@
+use crate::measurements::types::{Bytes, BytesPerSecond, RequestId};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-
-pub type Bytes = u128;
-pub type BytesPerSecond = f64;
-pub type RequestId = String;
 
 #[derive(Clone)]
 pub struct Bandwidth {

--- a/crates/ursa-network/src/measurements/latency.rs
+++ b/crates/ursa-network/src/measurements/latency.rs
@@ -1,6 +1,5 @@
+use crate::measurements::types::Milliseconds;
 use std::time::Duration;
-
-pub type Milliseconds = f64;
 
 #[derive(Clone)]
 pub struct Latency {

--- a/crates/ursa-network/src/measurements/mod.rs
+++ b/crates/ursa-network/src/measurements/mod.rs
@@ -117,7 +117,7 @@ mod tests {
     use std::time::Duration;
     use types::RequestId;
 
-    const EPSILON: f64 = 1e-6;
+    const EPSILON: f64 = 1e-4;
 
     #[test]
     fn test_one_request() {

--- a/crates/ursa-network/src/measurements/mod.rs
+++ b/crates/ursa-network/src/measurements/mod.rs
@@ -222,7 +222,7 @@ mod tests {
         let measurement = measurements.get(&peer_id).unwrap();
         let uptime = measurement.uptime.unwrap();
         // Relaxed timing requirements to make test work on macos
-        assert!(uptime >= 1000.0 && uptime < 2000.0);
+        assert!((1000.0..2000.0).contains(&uptime))
     }
 
     #[test]

--- a/crates/ursa-network/src/measurements/mod.rs
+++ b/crates/ursa-network/src/measurements/mod.rs
@@ -220,7 +220,9 @@ mod tests {
 
         let measurements = manager.get_measurements();
         let measurement = measurements.get(&peer_id).unwrap();
-        assert!((measurement.uptime.unwrap() - 1000.0).abs() < EPSILON);
+        let uptime = measurement.uptime.unwrap();
+        // Relaxed timing requirements to make test work on macos
+        assert!(uptime >= 1000.0 && uptime < 2000.0);
     }
 
     #[test]

--- a/crates/ursa-network/src/measurements/types.rs
+++ b/crates/ursa-network/src/measurements/types.rs
@@ -1,0 +1,4 @@
+pub type Bytes = u128;
+pub type BytesPerSecond = f64;
+pub type Milliseconds = f64;
+pub type RequestId = String;

--- a/crates/ursa-network/src/measurements/uptime.rs
+++ b/crates/ursa-network/src/measurements/uptime.rs
@@ -1,0 +1,48 @@
+use crate::measurements::types::Milliseconds;
+use std::time::{Duration, Instant};
+
+#[cfg(not(test))]
+const MAX_TIME_BETWEEN_PINGS: Duration = Duration::from_secs(60);
+#[cfg(test)]
+const MAX_TIME_BETWEEN_PINGS: Duration = Duration::from_secs(2);
+
+pub struct Uptime {
+    last_ping: Option<Instant>,
+    uptime: Milliseconds,
+}
+
+impl Uptime {
+    pub fn new() -> Self {
+        Self {
+            last_ping: None,
+            uptime: 0.0,
+        }
+    }
+
+    pub fn register_ping(&mut self) {
+        let now = Instant::now();
+        if let Some(last_ping) = self.last_ping {
+            let elapsed = last_ping.elapsed();
+            if elapsed < MAX_TIME_BETWEEN_PINGS {
+                self.uptime += elapsed.as_millis() as f64;
+            } else {
+                self.uptime = 0.0;
+            }
+        }
+        self.last_ping = Some(now);
+    }
+
+    pub fn get_estimate(&self) -> Option<Milliseconds> {
+        match self.last_ping {
+            Some(last_ping) => {
+                let elapsed = last_ping.elapsed();
+                if elapsed < MAX_TIME_BETWEEN_PINGS {
+                    Some(self.uptime)
+                } else {
+                    Some(0.0)
+                }
+            }
+            None => None,
+        }
+    }
+}

--- a/crates/ursa-network/src/service.rs
+++ b/crates/ursa-network/src/service.rs
@@ -355,7 +355,7 @@ where
                     ping_event.peer.to_base58(),
                 );
                 self.peers.handle_rtt_received(rtt, ping_event.peer);
-                self.measurement_manager.register_rtt(ping_event.peer, rtt);
+                self.measurement_manager.register_ping(ping_event.peer, rtt);
             }
             Ok(libp2p::ping::Success::Pong) => {
                 trace!(


### PR DESCRIPTION
## Why
We need measurements for the metrics that will be used for the reputation system, see #452. This PR addresses uptime measurements.

## What
- Extended `MeasurementManager` to include uptime estimates.
- Uptime estimates for a given peer will be computed from pings. Each ping extends the estimated uptime. If the interval between two pings is larger than 60 seconds, the uptime will be reset to 0.
- Moved all type definitions into `measurements/types.rs`.

## Notes
The max interval of 60 seconds was chosen as follows:
- The ping behaviour will send a ping every 15 seconds (libp2p default).
- To account for network fluctuations, we add a grace period of 45 seconds.
- 60 seconds is likely not enough time to restart a node, so we can assume that a node has been running during those 60 seconds.


## Checklist

- [x] I have made corresponding changes to the tests
- [N/A] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
