### PR TITLE
feat(pod): codec benchmarking for frames + multiblock fixes

### DIFF
--- a/crates/ursa-pod/Cargo.toml
+++ b/crates/ursa-pod/Cargo.toml
@@ -37,3 +37,7 @@ server = ["tokio", "tokio-stream", "futures", "tracing"]
 [[bench]]
 name = "encrypt"
 harness = false
+
+[[bench]]
+name = "codec"
+harness = false

--- a/crates/ursa-pod/benches/codec.rs
+++ b/crates/ursa-pod/benches/codec.rs
@@ -14,7 +14,7 @@ fn bench_frame<T: Measurement>(g: &mut BenchmarkGroup<T>, frame: UrsaFrame, titl
     g.throughput(Throughput::Bytes(frame.size_hint() as u64));
     let mut codec = UrsaCodec::default();
 
-    g.bench_function(format!("encode/{title}"), |b| {
+    g.bench_function(format!("{title}/encode"), |b| {
         let mut result = BytesMut::new();
         b.iter(|| {
             codec.encode(frame.clone(), &mut result).unwrap();
@@ -24,7 +24,7 @@ fn bench_frame<T: Measurement>(g: &mut BenchmarkGroup<T>, frame: UrsaFrame, titl
 
     let mut bytes = BytesMut::new();
     codec.encode(frame, &mut bytes).unwrap();
-    g.bench_function(format!("decode/{title}"), |b| {
+    g.bench_function(format!("{title}/decode"), |b| {
         b.iter(|| {
             let res = codec.decode(&mut bytes.clone()).unwrap();
             black_box(res);
@@ -33,7 +33,7 @@ fn bench_frame<T: Measurement>(g: &mut BenchmarkGroup<T>, frame: UrsaFrame, titl
 }
 
 fn bench_encode_group(c: &mut Criterion) {
-    let mut g = c.benchmark_group("codec");
+    let mut g = c.benchmark_group("Codec");
     g.sample_size(20);
     g.measurement_time(Duration::from_secs(15));
 

--- a/crates/ursa-pod/benches/codec.rs
+++ b/crates/ursa-pod/benches/codec.rs
@@ -1,0 +1,116 @@
+#![feature(core_intrinsics)]
+
+use std::time::Duration;
+
+use arrayref::array_ref;
+use benchmarks_utils::*;
+use bytes::BytesMut;
+use criterion::{measurement::Measurement, *};
+use tokio_util::codec::{Decoder, Encoder};
+
+use ursa_pod::codec::{Reason, UrsaCodec, UrsaFrame};
+
+fn bench_frame<T: Measurement>(g: &mut BenchmarkGroup<T>, frame: UrsaFrame, title: &'static str) {
+    g.throughput(Throughput::Bytes(frame.size_hint() as u64));
+    let mut codec = UrsaCodec::default();
+
+    g.bench_function(format!("encode/{title}"), |b| {
+        let mut result = BytesMut::new();
+        b.iter(|| {
+            codec.encode(frame.clone(), &mut result).unwrap();
+            black_box(&result);
+        })
+    });
+
+    let mut bytes = BytesMut::new();
+    codec.encode(frame, &mut bytes).unwrap();
+    g.bench_function(format!("decode/{title}"), |b| {
+        b.iter(|| {
+            let res = codec.decode(&mut bytes.clone()).unwrap();
+            black_box(res);
+        })
+    });
+}
+
+fn bench_encode_group(c: &mut Criterion) {
+    let mut g = c.benchmark_group("codec");
+    g.sample_size(20);
+    g.measurement_time(Duration::from_secs(15));
+
+    // Handshake request
+    let pubkey = random_vec(48);
+    let frame = UrsaFrame::HandshakeRequest {
+        version: 0,
+        supported_compression_bitmap: 0,
+        lane: None,
+        pubkey: *array_ref!(pubkey, 0, 48),
+    };
+    bench_frame(&mut g, frame, "handshake_request");
+
+    // Handshake response
+    let pubkey = random_vec(33);
+    let frame = UrsaFrame::HandshakeResponse {
+        pubkey: *array_ref![pubkey, 0, 33],
+        epoch_nonce: 65535,
+        lane: 0,
+        last: None,
+    };
+    bench_frame(&mut g, frame, "handshake_response");
+
+    // Content request
+    let cid = random_vec(32);
+    let frame = UrsaFrame::ContentRequest {
+        hash: *array_ref!(cid, 0, 32),
+    };
+    bench_frame(&mut g, frame, "content_request");
+
+    // Content range request
+    let data = random_vec(32);
+    let frame = UrsaFrame::ContentRangeRequest {
+        hash: *array_ref!(data, 0, 32),
+        chunk_start: 0,
+        chunks: 1,
+    };
+    bench_frame(&mut g, frame, "content_range_request");
+
+    // Content response (frame only)
+    let signature = random_vec(64);
+    let frame = UrsaFrame::ContentResponse {
+        compression: 0,
+        proof_len: 0,
+        block_len: 0,
+        signature: *array_ref!(signature, 0, 64),
+    };
+    bench_frame(&mut g, frame, "content_response");
+
+    // Decryption key request
+    let signature = random_vec(96);
+    let frame = UrsaFrame::DecryptionKeyRequest {
+        delivery_acknowledgment: *array_ref!(signature, 0, 96),
+    };
+    bench_frame(&mut g, frame, "decryption_key_request");
+
+    // Decryption key response
+    let data = random_vec(33);
+    let frame = UrsaFrame::DecryptionKeyResponse {
+        decryption_key: *array_ref!(data, 0, 33),
+    };
+    bench_frame(&mut g, frame, "decryption_key_response");
+
+    // Update epoch Signal
+    let frame = UrsaFrame::UpdateEpochSignal(65535);
+    bench_frame(&mut g, frame, "update_epoch_signal");
+
+    // End of request signal
+    let frame = UrsaFrame::EndOfRequestSignal;
+    bench_frame(&mut g, frame, "end_of_request_signal");
+
+    // Termination signal
+    let frame = UrsaFrame::TerminationSignal(Reason::Unknown);
+    bench_frame(&mut g, frame, "termination_signal");
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_encode_group);
+criterion_main!(benches);

--- a/crates/ursa-pod/benches/codec.rs
+++ b/crates/ursa-pod/benches/codec.rs
@@ -78,7 +78,8 @@ fn bench_encode_group(c: &mut Criterion) {
     let frame = UrsaFrame::ContentResponse {
         compression: 0,
         proof_len: 0,
-        block_len: 0,
+        // 0 len block is an error!
+        block_len: 1,
         signature: *array_ref!(signature, 0, 64),
     };
     bench_frame(&mut g, frame, "content_response");

--- a/crates/ursa-pod/benches/encrypt.rs
+++ b/crates/ursa-pod/benches/encrypt.rs
@@ -2,7 +2,6 @@
 
 use benchmarks_utils::*;
 use criterion::*;
-use elliptic_curve::Field;
 use rand_core::OsRng;
 use ursa_pod::keys::SecretKey;
 use ursa_pod::primitives::{encrypt_block, RequestInfo};
@@ -15,7 +14,7 @@ fn bench_encrypt(c: &mut Criterion) {
     g.throughput(Throughput::Bytes(SIZE as u64));
 
     let data = random_vec(SIZE);
-    let s_key = SecretKey(k256::Scalar::random(OsRng));
+    let s_key = SecretKey::random(OsRng);
     let req = RequestInfo::rand(OsRng);
 
     g.bench_function("encrypt", |b| {

--- a/crates/ursa-pod/examples/server.rs
+++ b/crates/ursa-pod/examples/server.rs
@@ -8,12 +8,14 @@ use ursa_pod::{
     types::{Blake3Cid, BlsSignature, Secp256k1PublicKey},
 };
 
+const CONTENT: &[u8] = &[0; 257 * 1024];
+
 #[derive(Clone, Copy)]
 struct DummyBackend {}
 
 impl Backend for DummyBackend {
     fn raw_content(&self, _cid: Blake3Cid) -> (BytesMut, u64) {
-        let content = BytesMut::from("hello world!");
+        let content = BytesMut::from(CONTENT);
         let request_id = 0;
         (content, request_id)
     }

--- a/crates/ursa-pod/examples/server.rs
+++ b/crates/ursa-pod/examples/server.rs
@@ -8,7 +8,7 @@ use ursa_pod::{
     types::{Blake3Cid, BlsSignature, Secp256k1PublicKey},
 };
 
-const CONTENT: &[u8] = &[0; 257 * 1024];
+const CONTENT: &[u8] = &[0; 512 * 1024];
 
 #[derive(Clone, Copy)]
 struct DummyBackend {}

--- a/crates/ursa-pod/src/codec.rs
+++ b/crates/ursa-pod/src/codec.rs
@@ -292,6 +292,7 @@ pub enum UrsaCodecError {
     InvalidTag(u8),
     InvalidReason(u8),
     UnexpectedFrame(FrameTag),
+    ZeroLengthBlock,
     Io(std::io::Error),
     Unknown,
 }
@@ -499,6 +500,9 @@ impl Decoder for UrsaCodec {
                 let proof_len = u64::from_be_bytes(proof_len_bytes);
                 let block_len_bytes = *array_ref!(buf, 10, 8);
                 let block_len = u64::from_be_bytes(block_len_bytes);
+                if block_len == 0 {
+                    return Err(UrsaCodecError::ZeroLengthBlock);
+                }
                 let signature = *array_ref!(buf, 18, 64);
 
                 Ok(Some(UrsaFrame::ContentResponse {


### PR DESCRIPTION
## Why

Add basic codec benchmarking for individual frames

## What

- add `benches/codec.rs`
- make examples exchange multiple blocks and fix client
- handle zero length:
  - block (codec error)
  - proof (skip proof state)

## Demo

![image](https://user-images.githubusercontent.com/8976745/229261518-d9ada922-abc4-41dd-ace0-e912f225ba8b.png)

## Checklist

- [x] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
