### PR TITLE
fix: pin snow to v0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ workspace-hack = { git = "https://github.com/fleek-network/empty-workspace-hack.
 
 [patch.'crates-io']
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d8de86e991ad540e6f69ca417c27f7407198944f" }
+snow = { git = "https://github.com/mcginty/snow", rev = "abf198913935decc5235e1c091571a3e1aebdf6c" }
 
 [profile.release]
 # 2 full, 0 nothing, 1 good enough.


### PR DESCRIPTION
## Why
The build fails because `libp2p-noise v0.41.0` is suddenly pulling in `snow v0.9.0` instead of `snow v0.9.2`.

## What
- Pin `snow` to 0.9.2


## Checklist

- [N/A] I have made corresponding changes to the tests
- [N/A] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
