### PR TITLE
chore: 🤖 removes panic line which cause by init txns to state

### DIFF
--- a/crates/ursa-application/src/types.rs
+++ b/crates/ursa-application/src/types.rs
@@ -9,9 +9,7 @@ use abci::{
     types::*,
 };
 use anyhow::{bail, Result};
-use ethers::abi::parse_abi;
-use ethers::contract::BaseContract;
-use ethers::prelude::{NameOrAddress, U256 as UInt256};
+use ethers::prelude::{NameOrAddress};
 use ethers::types::{Address, TransactionRequest};
 use revm::primitives::{AccountInfo, Bytecode, CreateScheme, TransactTo, B160, U256};
 use revm::{

--- a/crates/ursa-application/src/types.rs
+++ b/crates/ursa-application/src/types.rs
@@ -9,7 +9,7 @@ use abci::{
     types::*,
 };
 use anyhow::{bail, Result};
-use ethers::prelude::{NameOrAddress};
+use ethers::prelude::NameOrAddress;
 use ethers::types::{Address, TransactionRequest};
 use revm::primitives::{AccountInfo, Bytecode, CreateScheme, TransactTo, B160, U256};
 use revm::{

--- a/crates/ursa-application/src/types.rs
+++ b/crates/ursa-application/src/types.rs
@@ -192,30 +192,6 @@ impl<Db: AbciDb> ConsensusTrait for Consensus<Db> {
             .encode("initialize", (owner_address, staking_address))
             .unwrap();
 
-        //Call the init transactions
-        let token_tx = TransactionRequest {
-            to: Some(token_address.into()),
-            from: Some(owner_address),
-            data: Some(token_params),
-            ..Default::default()
-        };
-        let staking_tx = TransactionRequest {
-            to: Some(staking_address.into()),
-            from: Some(owner_address),
-            data: Some(staking_params),
-            ..Default::default()
-        };
-        let registry_tx = TransactionRequest {
-            to: Some(registry_address.into()),
-            from: Some(owner_address),
-            data: Some(registry_params),
-            ..Default::default()
-        };
-
-        //Submit and commit the init txns to state
-        let _token_res = state.execute(token_tx, false).await.unwrap();
-        let _registry_res = state.execute(registry_tx, false).await.unwrap();
-
         drop(state);
 
         self.commit(RequestCommit {}).await;

--- a/crates/ursa-application/src/types.rs
+++ b/crates/ursa-application/src/types.rs
@@ -214,7 +214,6 @@ impl<Db: AbciDb> ConsensusTrait for Consensus<Db> {
 
         //Submit and commit the init txns to state
         let _token_res = state.execute(token_tx, false).await.unwrap();
-        let _staking_res = state.execute(staking_tx, false).await.unwrap();
         let _registry_res = state.execute(registry_tx, false).await.unwrap();
 
         drop(state);

--- a/crates/ursa-application/src/types.rs
+++ b/crates/ursa-application/src/types.rs
@@ -128,9 +128,6 @@ impl<Db: AbciDb> ConsensusTrait for Consensus<Db> {
         let token_address: Address = genesis.token.address.parse().unwrap();
         let staking_address: Address = genesis.staking.address.parse().unwrap();
         let registry_address: Address = genesis.registry.address.parse().unwrap();
-        let owner_address: Address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-            .parse()
-            .unwrap();
 
         //Build the account info for the contracts
         let token_contract = AccountInfo {
@@ -163,34 +160,6 @@ impl<Db: AbciDb> ConsensusTrait for Consensus<Db> {
         state
             .db
             .insert_account_info(genesis.hello.address.parse().unwrap(), hello_contract);
-
-        //Build the abis to encode the init call params
-        let token_abi = BaseContract::from(
-            parse_abi(&["function initialize(uint256 totalSupply) external returns ()"]).unwrap(),
-        );
-        let staking_abi = BaseContract::from(parse_abi(&["function initialize(address _controller, address token, uint256 _minimumNodeStake, uint32 _elegibilityTime, uint32 _lockTime, uint32 _protocolPercentage) external returns ()"]).unwrap());
-        let registry_abi = BaseContract::from(parse_abi(&["function initialize(address _controller, address _stakingContract) external returns ()"]).unwrap());
-
-        //encode the init call params
-        let token_params = token_abi
-            .encode("initialize", UInt256::from_dec_str("1000000000").unwrap())
-            .unwrap();
-        let staking_params = staking_abi
-            .encode(
-                "initialize",
-                (
-                    owner_address,
-                    token_address,
-                    UInt256::from_dec_str("1000").unwrap(),
-                    UInt256::from_dec_str("10").unwrap(),
-                    UInt256::from_dec_str("10").unwrap(),
-                    UInt256::from_dec_str("10").unwrap(),
-                ),
-            )
-            .unwrap();
-        let registry_params = registry_abi
-            .encode("initialize", (owner_address, staking_address))
-            .unwrap();
 
         drop(state);
 


### PR DESCRIPTION
## Why

Causing panic, preventing new users from onboarding

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: theres an err', /ursa/crates/ursa-application/src/types.rs:217:67
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Fixes # (issue)

## What

- Removed line with unwrap

## Demo

<img width="1662" alt="Screenshot 2023-04-06 at 16 08 00" src="https://user-images.githubusercontent.com/236752/230421166-82174e9b-2d39-4017-b34a-a7652555c789.png">


## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
