### PR TITLE
chore: update PR based triggers for gh workflows to skip draft PRs

### DIFF
--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -7,6 +7,8 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
+    types: [review_requested, ready_for_review]
+
 jobs:
   build:
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})

--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -7,10 +7,10 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [ready_for_review]
 
 jobs:
   build:
+    if: '! github.event.pull_request.draft'
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -7,7 +7,7 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-    if: '! github.event.pull_request.draft'
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -7,7 +7,7 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   tests:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -7,10 +7,10 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [ready_for_review]
 
 jobs:
   tests:
+    if: '! github.event.pull_request.draft'
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,6 +26,7 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   clippy:
+    if: '! github.event.pull_request.draft'
     name: Lint with clippy
     runs-on: ubuntu-latest
     strategy:
@@ -35,6 +36,7 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   coverage:
+    if: '! github.event.pull_request.draft'
     name: Tests coverage
     runs-on: ubuntu-latest
     strategy:
@@ -44,6 +46,7 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   rustfmt:
+    if: '! github.event.pull_request.draft'
     name: Code formatting
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   tests:
-    if: '! github.event.pull_request.draft'
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,7 +25,6 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   clippy:
-    if: '! github.event.pull_request.draft'
     name: Lint with clippy
     runs-on: ubuntu-latest
     strategy:
@@ -36,7 +34,6 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   coverage:
-    if: '! github.event.pull_request.draft'
     name: Tests coverage
     runs-on: ubuntu-latest
     strategy:
@@ -46,7 +43,6 @@ jobs:
       - run: echo "No rust or workflow modifications, skipped!"
 
   rustfmt:
-    if: '! github.event.pull_request.draft'
     name: Code formatting
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -7,6 +7,8 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
+    types: [review_requested, ready_for_review]
+
 jobs:
   tests:
     name: Matrix tests (${{ matrix.os }})

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ on:
       - "**/Dockerfile*"
     types:
       - opened
+      - reopened
       - synchronize
       - ready_for_review
 
@@ -34,6 +35,7 @@ jobs:
   build:
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,7 @@ on:
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
       - "**/Dockerfile*"
+    types: [review_requested, ready_for_review]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,10 @@ on:
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
       - "**/Dockerfile*"
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
 
 env:
   REGISTRY: ghcr.io
@@ -28,7 +32,6 @@ env:
 
 jobs:
   build:
-    if: '! github.event.pull_request.draft'
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ on:
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
       - "**/Dockerfile*"
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,6 @@ on:
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
       - "**/Dockerfile*"
-    types: [ready_for_review]
 
 env:
   REGISTRY: ghcr.io
@@ -29,6 +28,7 @@ env:
 
 jobs:
   build:
+    if: '! github.event.pull_request.draft'
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,10 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [ready_for_review]
 
 jobs:
   tests:
+    if: '! github.event.pull_request.draft'
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -79,6 +79,7 @@ jobs:
       - run: cargo test --workspace --no-default-features
 
   clippy:
+    if: '! github.event.pull_request.draft'
     name: Lint with clippy
     runs-on: ubuntu-latest
     strategy:
@@ -125,6 +126,7 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rustfmt:
+    if: '! github.event.pull_request.draft'
     name: Code formatting
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   tests:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
+    types: [review_requested, ready_for_review]
 
 jobs:
   tests:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,13 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
 
 jobs:
   tests:
-    if: '! github.event.pull_request.draft'
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -79,7 +82,6 @@ jobs:
       - run: cargo test --workspace --no-default-features
 
   clippy:
-    if: '! github.event.pull_request.draft'
     name: Lint with clippy
     runs-on: ubuntu-latest
     strategy:
@@ -126,7 +128,6 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rustfmt:
-    if: '! github.event.pull_request.draft'
     name: Code formatting
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,7 @@ on:
       - ".github/workflows/docker-publish.yml"
     types:
       - opened
+      - reopened
       - synchronize
       - ready_for_review
 
@@ -27,6 +28,7 @@ jobs:
   tests:
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +86,7 @@ jobs:
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         rust: [stable]
@@ -130,6 +133,7 @@ jobs:
   rustfmt:
     name: Code formatting
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         rust: [stable]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,16 +6,16 @@ on:
       - main
     paths:
       - 'infra/tf-next/**'
-  # question: do we need the PR trigger for terraform? maybe just
-  # config check for PRs and the terraform apply only runs for
-  # merges to main?
   pull_request:
     paths:
       - 'infra/tf-next/**'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
 
 jobs:
   terraform:
-    if: '! github.event.pull_request.draft'
     name: "Terraform"
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,9 +6,13 @@ on:
       - main
     paths:
       - 'infra/tf-next/**'
+  # question: do we need the PR trigger for terraform? maybe just
+  # config check for PRs and the terraform apply only runs for
+  # merges to main?
   pull_request:
     paths:
       - 'infra/tf-next/**'
+    types: [review_requested, ready_for_review]
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,10 +12,10 @@ on:
   pull_request:
     paths:
       - 'infra/tf-next/**'
-    types: [ready_for_review]
 
 jobs:
   terraform:
+    if: '! github.event.pull_request.draft'
     name: "Terraform"
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,7 @@ on:
       - 'infra/tf-next/**'
     types:
       - opened
+      - reopened
       - synchronize
       - ready_for_review
 
@@ -18,6 +19,7 @@ jobs:
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     defaults:
       run:
         working-directory: infra/tf-next

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     paths:
       - 'infra/tf-next/**'
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   terraform:

--- a/crates/ursa/src/config.rs
+++ b/crates/ursa/src/config.rs
@@ -15,7 +15,7 @@ use ursa_network::NetworkConfig;
 use ursa_rpc_service::config::ServerConfig;
 
 pub const DEFAULT_CONFIG_PATH_STR: &str = ".ursa/config.toml";
- 
+
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct UrsaConfig {
     #[serde(default)]

--- a/crates/ursa/src/config.rs
+++ b/crates/ursa/src/config.rs
@@ -15,7 +15,7 @@ use ursa_network::NetworkConfig;
 use ursa_rpc_service::config::ServerConfig;
 
 pub const DEFAULT_CONFIG_PATH_STR: &str = ".ursa/config.toml";
-
+ 
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct UrsaConfig {
     #[serde(default)]


### PR DESCRIPTION
## Why

This is was mentioned on Discord by @qti3e so I thought I'd make a small PR to get familiar with the CI setup and add that filter.  Not sure if this works yet but will create the draft PRs and see.

Fixes # (issue)

## What

- Each workflow file will now have a setting on the PR based triggers to only trigger on PRs that are ready for review

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

See note on the Terraform build - feel like we can maybe only run those on merges to main?

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
