### PR TITLE
feat(proxy): add metrics

### DIFF
--- a/crates/ursa-proxy/Cargo.toml
+++ b/crates/ursa-proxy/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 axum.workspace = true
+axum-prometheus.workspace = true
 axum-server.workspace = true
 axum-tracing-opentelemetry.workspace = true
 bytes.workspace = true

--- a/crates/ursa-proxy/README.md
+++ b/crates/ursa-proxy/README.md
@@ -9,3 +9,8 @@ While the proxy is running you can send it commands via the admin server.
 The admin server has two endpoints:
 * `/purge` will purge the cache. 
 * `/reload-tls-config` will reload the TLS config. Use this if you want to reload the certificates.
+
+## Metrics
+
+We use [axum_prometheus](https://docs.rs/axum-prometheus/latest/axum_prometheus/) to collect 
+HTTP metrics. This data can be accessed using endpoint `/metrics`.


### PR DESCRIPTION
Adds a Prometheus middleware to collect HTTP metrics.

## Demo
```
curl -v http://0.0.0.0:8080/metrics

# TYPE axum_http_requests_total counter
axum_http_requests_total{method="GET",status="200",endpoint="/*path"} 110001

# TYPE axum_http_requests_pending gauge
axum_http_requests_pending{method="GET",endpoint="/*path"} 0

# TYPE axum_http_requests_duration_seconds histogram
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.005"} 3653
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.01"} 17466
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.025"} 92401
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.05"} 108438
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.1"} 109766
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.25"} 109998
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="0.5"} 110001
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="1"} 110001
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="2.5"} 110001
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="5"} 110001
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="10"} 110001
axum_http_requests_duration_seconds_bucket{method="GET",status="200",endpoint="/*path",le="+Inf"} 110001
axum_http_requests_duration_seconds_sum{method="GET",status="200",endpoint="/*path"} 1998.8198700489959
axum_http_requests_duration_seconds_count{method="GET",status="200",endpoint="/*path"} 110001
```

Prometheus can consume data from `/metrics`.

<img width="1480" alt="image" src="https://user-images.githubusercontent.com/24687641/232888708-d0873ae4-6428-4eb0-884b-eb530fa0ea56.png">


## Checklist

- [ ] ~I have made corresponding changes to the tests~
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
