### PR TITLE
chore: 🤖 ursa proxy docker image builder and publisher (revisited)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   GATEWAY_IMAGE_NAME: ${{ github.repository }}-gateway
+  PROXY_IMAGE_NAME: ${{ github.repository }}-proxy
 
 jobs:
   build:
@@ -97,15 +98,6 @@ jobs:
             type=raw,value=${{ github.head_ref || github.ref_name }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      - name: Build and push Docker image (ursa)
-        id: ursa-build-and-push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: ${{ github.ref == 'refs/heads/main' }}
-          tags: ${{ steps.ursa-meta.outputs.tags }}
-          labels: ${{ steps.ursa-meta.outputs.labels }}
-
       - name: Extract Docker metadata (ursa-gateway)
         id: ursa-gateway-meta
         uses: docker/metadata-action@v4.0.1
@@ -119,6 +111,28 @@ jobs:
             type=raw,value=${{ github.head_ref || github.ref_name }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
+      - name: Extract Docker metadata (ursa-proxy)
+        id: ursa-proxy-meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.PROXY_IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr,prefix=pr-
+            type=ref,event=tag,prefix=tag-
+            type=raw,value=${{ github.head_ref || github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push Docker image (ursa)
+        id: ursa-build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.ursa-meta.outputs.tags }}
+          labels: ${{ steps.ursa-meta.outputs.labels }}
+
       - name: Build and push Docker image (ursa-gateway)
         id: ursa-gateway-build-and-push
         uses: docker/build-push-action@v3 
@@ -128,3 +142,13 @@ jobs:
           tags: ${{ steps.ursa-gateway-meta.outputs.tags }}
           labels: ${{ steps.ursa-gateway-meta.outputs.labels }}
           file: Dockerfile-gateway
+
+      - name: Build and push Docker image (ursa-proxy)
+        id: ursa-proxy-build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.ursa-proxy-meta.outputs.tags }}
+          labels: ${{ steps.ursa-proxy-meta.outputs.labels }}
+          file: Dockerfile-proxy


### PR DESCRIPTION
## Why

Add the ursa-proxy docker image build and publish in the github workflow by declaring the metadata and build steps.

⚠️ Replaces https://github.com/fleek-network/ursa/pull/509 that had the pending PR https://github.com/fleek-network/ursa/pull/506 as a dependency

## What

- Github workflow "docker-build-push"

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

Depends on (refactor: 💡 ursa proxy in docker https://github.com/fleek-network/ursa/pull/506) that should be integrated first

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
