### PR TITLE
chore: run CI only when not draft

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,6 +35,7 @@ jobs:
   build:
     name: Docker build and publish ${{ matrix.make.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,11 @@ on:
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
       - "**/Dockerfile*"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,11 +18,17 @@ on:
       - "Cargo.toml"
       - ".github/workflows/rust.yml"
       - ".github/workflows/docker-publish.yml"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   tests:
     name: Matrix tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +86,7 @@ jobs:
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         rust: [stable]
@@ -126,6 +133,7 @@ jobs:
   rustfmt:
     name: Code formatting
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         rust: [stable]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,11 +9,17 @@ on:
   pull_request:
     paths:
       - 'infra/tf-next/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     defaults:
       run:
         working-directory: infra/tf-next


### PR DESCRIPTION
## Why

This replaces #498. This is was mentioned on Discord by @qti3e so I thought I'd make a small PR to get familiar with the CI setup and add that filter.  Not sure if this works yet but will create the draft PRs and see.

Fixes # (issue)
n/a

## What

- Each workflow file will now have a setting on the PR based triggers to only trigger on PRs that are ready for review and also filter on draft status
-  Solution from the help of Oz and https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887

## Demo

You can see the different settings and tests that were done on the superceded PR https://github.com/fleek-network/ursa/pull/498.

## Notes

See note on the Terraform build - feel like we can maybe only run those on merges to main?

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
