### PR TITLE
fix(proxy): init recorder once

### DIFF
--- a/crates/ursa-proxy/README.md
+++ b/crates/ursa-proxy/README.md
@@ -9,8 +9,4 @@ While the proxy is running you can send it commands via the admin server.
 The admin server has two endpoints:
 * `/purge` will purge the cache. 
 * `/reload-tls-config` will reload the TLS config. Use this if you want to reload the certificates.
-
-## Metrics
-
-We use [axum_prometheus](https://docs.rs/axum-prometheus/latest/axum_prometheus/) to collect 
-HTTP metrics. This data can be accessed using endpoint `/metrics`.
+* `/metrics` is for accessing HTTP metrics stored via prometheus recorder.


### PR DESCRIPTION
## Why

<!-- Please include a summary of why the pull request is needed, including motivation and context --->

The issue is that proxy is initializing a recorder several times which is not allowed https://docs.rs/metrics/0.21.0/metrics/fn.set_recorder.html

> An error is returned if a recorder has already been set.

## What

<!-- Please include a bulleted list of what the pull request is changing --->

- Init recorder once.
- Access metrics via admin's `/metric` endpoint.

## Checklist

- [ ] ~I have made corresponding changes to the tests~
- [x] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
