### PR TITLE
fix: hanging after multiple frames are read at once

### DIFF
--- a/crates/ursa-pod/src/connection.rs
+++ b/crates/ursa-pod/src/connection.rs
@@ -479,6 +479,10 @@ where
     #[inline(always)]
     pub async fn read_frame(&mut self, filter: Option<u8>) -> std::io::Result<Option<UrsaFrame>> {
         loop {
+            if let Some(frame) = self.parse_frame(filter)? {
+                return Ok(Some(frame));
+            }
+
             if 0 == self.stream.read_buf(&mut self.read_buffer).await? {
                 // The remote closed the connection. For this to be
                 // a clean shutdown, there should be no data in the
@@ -492,10 +496,6 @@ where
                         "Client disconnected",
                     ));
                 }
-            }
-
-            if let Some(frame) = self.parse_frame(filter)? {
-                return Ok(Some(frame));
             }
         }
     }


### PR DESCRIPTION
## Why

fixes hanging when multiple frames are read into the buffer at once

## Checklist

- [-] I have made corresponding changes to the tests
- [-] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
