### PR TITLE
pod: frame filters and alloc improvement

### DIFF
--- a/crates/ursa-pod/benchmarks/parser/main.rs
+++ b/crates/ursa-pod/benchmarks/parser/main.rs
@@ -190,7 +190,7 @@ fn plot(path: Option<PathBuf>, param: String) {
 
     let mut fg = Figure::new();
     fg.axes2d()
-        .set_x_label(&param.replace("_", " "), &[])
+        .set_x_label(&param.replace('_', " "), &[])
         .set_y_label("elapsed (μs)", &[])
         .lines(&x.clone(), y_mean, &[Caption("Mean"), Color("black")])
         .lines(&x, y_median, &[Caption("Median"), Color("red")])

--- a/crates/ursa-pod/benchmarks/parser/stat.rs
+++ b/crates/ursa-pod/benchmarks/parser/stat.rs
@@ -24,13 +24,13 @@ pub fn sum_mean(list: &[u64]) -> (u128, f64) {
 }
 
 /// Compute the normalized average
-pub fn normalized_avg(list: &mut Vec<u64>) -> f64 {
+pub fn _normalized_avg(list: &mut Vec<u64>, mean: Option<f64>) -> f64 {
     let prev_len = list.len();
-    let avg = sum_mean(list.as_slice()).1;
-    let sd = stddev(list.as_slice(), Some(avg));
-    list.retain(|&n| n as f64 >= avg - sd && n as f64 <= avg + sd);
+    let mean = mean.unwrap_or_else(|| sum_mean(list).1);
+    let sd = stddev(list.as_slice(), Some(mean));
+    list.retain(|&n| n as f64 >= mean - sd && n as f64 <= mean + sd);
     match list.len() {
-        len if len == prev_len => avg,
+        len if len == prev_len => mean,
         _ => sum_mean(list).1,
     }
 }
@@ -65,10 +65,7 @@ pub fn stddev(list: &[u64], mean: Option<f64>) -> f64 {
     if list.len() <= 1 {
         return 0.0;
     }
-    let mean = match mean {
-        Some(m) => m,
-        None => sum_mean(list).1,
-    };
+    let mean = mean.unwrap_or_else(|| sum_mean(list).1);
     mega_stddev_sum(list, list.len() as f64, mean).sqrt()
 }
 

--- a/crates/ursa-pod/examples/server.rs
+++ b/crates/ursa-pod/examples/server.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<(), UrsaCodecError> {
 
     let listener = TcpListener::bind(addr).await.unwrap();
     loop {
-        info!("accepted conn");
         let (stream, _) = listener.accept().await.unwrap();
+        info!("accepted conn");
         let handler = UfdpHandler::new(stream, DummyBackend {}, 0);
 
         if let Err(e) = handler.serve().await {

--- a/crates/ursa-pod/src/client.rs
+++ b/crates/ursa-pod/src/client.rs
@@ -93,9 +93,7 @@ where
                                     break;
                                 }
                             }
-                            Some(e) => {
-                                return Err(UrsaCodecError::InvalidTag(e.tag().unwrap() as u8))
-                            }
+                            Some(_) => unreachable!(), // Guaranteed by read_buffer()
                             None => return Err(UrsaCodecError::Unknown),
                         }
                     }
@@ -116,8 +114,7 @@ where
                                     break;
                                 }
                             }
-                            // SAFETY: will always return a buffer because of read_buffer() call
-                            Some(_) => unreachable!(),
+                            Some(_) => unreachable!(), // Guaranteed by read_buffer()
                             None => return Err(UrsaCodecError::Unknown),
                         }
                     }
@@ -141,7 +138,7 @@ where
                         Some(UrsaFrame::DecryptionKeyResponse { .. }) => {
                             // todo: decrypt block & verify data
                         }
-                        Some(_) => unreachable!(),
+                        Some(_) => unreachable!(), // Guaranteed by frame filter
                         _ => return Err(UrsaCodecError::Unknown),
                     }
                 }

--- a/crates/ursa-pod/src/connection.rs
+++ b/crates/ursa-pod/src/connection.rs
@@ -203,7 +203,7 @@ pub enum UrsaFrame {
         block_len: u64,
         signature: SchnorrSignature,
     },
-    /// Not a frame. Buffer contains a chunk of bytes initiated after the `UrsaCodec::frame_buffer` method has been called.
+    /// Not a frame. Buffer contains a chunk of bytes initiated after the [`UfdpConnection::read_buffer`] method has been called.
     /// It does *not* have a tag, and is used to chunk bytes after a [`UrsaFrame::ContentResponse`].
     Buffer(BytesMut),
     /// Client request for a range of chunks of content

--- a/crates/ursa-pod/src/instrument.rs
+++ b/crates/ursa-pod/src/instrument.rs
@@ -14,6 +14,7 @@ macro_rules! instrument {
             }
             let identifiers = format!($($t)*);
             let start = now();
+            println!("START,uid={location},{identifiers}");
             let val = { $e };
             println!("SAMPLE,start={start},end={end},uid={location},{identifiers}", end = now());
             val

--- a/crates/ursa-pod/src/server.rs
+++ b/crates/ursa-pod/src/server.rs
@@ -85,7 +85,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin, B: Backend> UfdpHandler<S, B> {
                     );
                 }
                 UrsaFrame::ContentRangeRequest { .. } => todo!(),
-                _ => unreachable!(),
+                _ => unreachable!(), // Guaranteed by frame filter
             }
         }
 
@@ -101,7 +101,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin, B: Backend> UfdpHandler<S, B> {
             self.session_id
         ) {
             Some(UrsaFrame::HandshakeRequest { lane, .. }) => {
-                // send res frame
+                // Send res frame
                 instrument!(
                     self.conn
                         .write_frame(UrsaFrame::HandshakeResponse {
@@ -118,8 +118,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin, B: Backend> UfdpHandler<S, B> {
                 Ok(())
             }
             None => Err(UrsaCodecError::Unknown),
-            // handled by filter
-            Some(_) => unreachable!(),
+            Some(_) => unreachable!(), // Guaranteed by frame filter
         }
     }
 
@@ -186,7 +185,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin, B: Backend> UfdpHandler<S, B> {
                     // todo: transaction manager (batch and store tx)
                 }
                 None => return Err(UrsaCodecError::Unknown),
-                Some(_) => unreachable!(),
+                Some(_) => unreachable!(), // Guaranteed by frame filter
             }
 
             // Send decryption key


### PR DESCRIPTION
## Why

resolves todo for implementing frame filters, and improves some allocations for the inner buffer.

## What

- add frame filter impl
- bring back read_buffer and reserve the len in the inner buffer
- whenever reading a frame, reserve the len again to make sure self.buffer always has at least 148 bytes available (max frame size)
- also added some minor cleanup in example server and ufdp-bench-parser
- improved code comments and added some todos

## Checklist

- [-] I have made corresponding changes to the tests
- [-] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
