### PR TITLE
fix: 🐛 use axums fix "Fix fallback panic on CONNECT requests"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/fleek-network/ursa"
 anyhow = "1.0.67"
 async-fs = "1.6.0"
 async-trait = "0.1.60"
-axum = { version = "0.6.1", features = ["multipart", "headers"] }
+axum = { git = "https://github.com/tokio-rs/axum.git", rev = "87530c9", features = ["multipart", "headers"] }
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 base64 = "0.13.0"
 bincode = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/fleek-network/ursa"
 anyhow = "1.0.67"
 async-fs = "1.6.0"
 async-trait = "0.1.60"
-axum = { git = "https://github.com/tokio-rs/axum.git", rev = "87530c9", features = ["multipart", "headers"] }
+axum = { version = "0.6.17", features = ["multipart", "headers"] }
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 base64 = "0.13.0"
 bincode = "1.3.3"


### PR DESCRIPTION
## Why

Fix for fallback panic on CONNECT requests that was initially reported here https://github.com/fleek-network/ursa/issues/522, and fix provided here https://github.com/tokio-rs/axum/pull/1958

Fixes # (issue)

https://github.com/fleek-network/ursa/issues/522

## What

- Cargo.toml's axium package version as git repository and revision commit hash, until the PR (https://github.com/tokio-rs/axum/pull/1958) is integrated and release

## Demo

Native build via the assisted installer

<img width="1525" alt="Screenshot 2023-04-25 at 13 57 30" src="https://user-images.githubusercontent.com/236752/234283441-1a425328-400c-4c9c-8863-0f7cf352c7c8.png">

This is a test where the ursa-proxy runs along the ursa build natively through cargo commands and not via the assisted installer

<img width="1675" alt="Screenshot 2023-04-25 at 13 58 11" src="https://user-images.githubusercontent.com/236752/234283594-531d102a-028f-4c26-b6e5-702ba2391555.png">


## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
