### PR TITLE
feat: blake3 integration for client and server

### DIFF
--- a/crates/ursa-pod/examples/client.rs
+++ b/crates/ursa-pod/examples/client.rs
@@ -1,11 +1,11 @@
 use tokio::net::TcpStream;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
-use ursa_pod::{client::UfdpClient, connection::UrsaCodecError, types::Blake3Cid};
+use ursa_pod::{blake3::Hash, client::UfdpClient, connection::UrsaCodecError};
 
 const SERVER_ADDRESS: &str = "127.0.0.1:6969";
 const PUB_KEY: [u8; 48] = [2u8; 48];
-const CID: Blake3Cid = Blake3Cid([1u8; 32]);
+const HASH: &str = "28960eef7d587ab6d1627b7efe30c7a07ce2dce4871d339fdfb607cb0776e064";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), UrsaCodecError> {
@@ -14,22 +14,16 @@ async fn main() -> Result<(), UrsaCodecError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    let mut handles = vec![];
+    let hash = Hash::from_hex(HASH).unwrap();
 
-    for _ in 0..1 {
-        #[cfg(not(feature = "bench-hyper"))]
-        handles.push(tokio::spawn(async {
-            let time = std::time::Instant::now();
-            let stream = TcpStream::connect(SERVER_ADDRESS).await.unwrap();
-            let mut client = UfdpClient::new(stream, PUB_KEY, None).await.unwrap();
-            let size = client.request(CID).await.unwrap();
+    info!("requesting hash {hash}");
+    let time = std::time::Instant::now();
+    let stream = TcpStream::connect(SERVER_ADDRESS).await.unwrap();
+    let mut client = UfdpClient::new(stream, PUB_KEY, None).await.unwrap();
+    let size = client.request(hash).await.unwrap();
 
-            let took = time.elapsed().as_millis();
-            info!("received {} bytes in {took}ms", size);
-        }));
-    }
-
-    futures::future::join_all(handles).await;
+    let took = time.elapsed().as_millis();
+    info!("received {} bytes in {took}ms", size);
 
     Ok(())
 }

--- a/crates/ursa-pod/examples/server.rs
+++ b/crates/ursa-pod/examples/server.rs
@@ -1,25 +1,32 @@
+use blake3::Hash;
 use tokio::net::TcpListener;
 use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
 use ursa_pod::{
     connection::UrsaCodecError,
     server::{Backend, UfdpHandler},
-    types::{Blake3Cid, BlsSignature, Secp256k1PublicKey},
+    types::{BlsSignature, Secp256k1PublicKey},
 };
 
 const CONTENT: &[u8] = &[0; 256 * 1024];
 
-#[derive(Clone, Copy)]
-struct DummyBackend {}
+#[derive(Clone)]
+struct DummyBackend {
+    tree: Vec<[u8; 32]>,
+}
+
+fn raw_block(block: u64) -> Option<&'static [u8]> {
+    // serve 10GB
+    if block < 4 * 1024 * 10 {
+        Some(CONTENT)
+    } else {
+        None
+    }
+}
 
 impl Backend for DummyBackend {
-    fn raw_block(&self, _cid: &Blake3Cid, block: u64) -> Option<&[u8]> {
-        // serve 10GB
-        if block < 4 * 1024 * 10 {
-            Some(CONTENT)
-        } else {
-            None
-        }
+    fn raw_block(&self, _cid: &Hash, block: u64) -> Option<&[u8]> {
+        raw_block(block)
     }
 
     fn decryption_key(&self, _request_id: u64) -> (ursa_pod::types::Secp256k1AffinePoint, u64) {
@@ -35,6 +42,10 @@ impl Backend for DummyBackend {
     fn save_batch(&self, _batch: BlsSignature) -> Result<(), String> {
         Ok(())
     }
+
+    fn get_tree(&self, _cid: &Hash) -> Option<Vec<[u8; 32]>> {
+        Some(self.tree.clone())
+    }
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -44,14 +55,22 @@ async fn main() -> Result<(), UrsaCodecError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
+    // build a 10GB blake3 tree
+    let mut tree_builder = blake3::ursa::HashTreeBuilder::new();
+    (0..4 * 1024 * 10).for_each(|_i| tree_builder.update(CONTENT));
+    let output = tree_builder.finalize();
+    let hash = output.hash;
+
+    let backend = DummyBackend { tree: output.tree };
     let addr = "127.0.0.1:6969";
-    info!("Listening on port 6969");
+    info!("Serving content on port 6969, for: {hash}");
 
     let listener = TcpListener::bind(addr).await.unwrap();
+
     loop {
         let (stream, _) = listener.accept().await.unwrap();
-        info!("accepted conn");
-        let handler = UfdpHandler::new(stream, DummyBackend {}, 0);
+        info!("handling connection");
+        let handler = UfdpHandler::new(stream, backend.clone(), 0);
 
         if let Err(e) = handler.serve().await {
             error!("UFDP Session failed: {e:?}");

--- a/crates/ursa-pod/src/types.rs
+++ b/crates/ursa-pod/src/types.rs
@@ -3,18 +3,6 @@ use std::fmt::Display;
 pub type EpochNonce = u64;
 pub type Secp256k1AffinePoint = [u8; 33];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Blake3Cid(pub [u8; 32]);
-
-impl Display for Blake3Cid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for byte in self.0 {
-            write!(f, "{byte:x}")?;
-        }
-        Ok(())
-    }
-}
-
 pub type Secp256k1PublicKey = Secp256k1AffinePoint;
 pub type SchnorrSignature = [u8; 64];
 


### PR DESCRIPTION
## Why

Integrates blake3 verified streaming to client and server implementations

## What

- Replace `types::Blake3Cid` with `blake3::Hash`
- Add `Backend::get_tree()`
- (server) send proofs
- (client) receive proofs and verify content

## Checklist

- [-] I have made corresponding changes to the tests
- [-] I have made corresponding changes to the documentation
- [x] I have run the app using my feature and ensured that no functionality is broken
