### PR TITLE
chore: 🤖 remove nginx exporter job

### DIFF
--- a/docker/full-node/data/prom/prometheus.yml
+++ b/docker/full-node/data/prom/prometheus.yml
@@ -17,7 +17,3 @@ scrape_configs:
   - job_name: "node-exporter"
     static_configs:
       - targets: ["node-exporter:9100"]
-
-  - job_name: 'nginxexporter'
-    static_configs:
-    - targets: ['nginxexporter:9113']


### PR DESCRIPTION
## Why

The nginx exporter job in the prometheus config file is not required because nginx has been removed from the docker compose stack configuration file.

Fixes # (issue)

## What

- removes prometheus nginxexporter job

## Demo

<!-- (optional) Include screenshots or links to showcase the changes made ---> 

## Notes

<!-- (optional) open questions, notable changes, or requirements to consider for reviewers -->

## Checklist

- [ ] I have made corresponding changes to the tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the app using my feature and ensured that no functionality is broken
